### PR TITLE
Action names can contain dots (.) if they are inside of controls bein…

### DIFF
--- a/src/p4pktgen/switch/simple_switch.py
+++ b/src/p4pktgen/switch/simple_switch.py
@@ -129,7 +129,7 @@ class SimpleSwitch:
                 table_name = m.group(1)
                 prev_match = 'table_apply'
                 continue
-            m = re.search(r'Action ([0-9a-zA-Z_]*)$', line)
+            m = re.search(r'Action ([0-9a-zA-Z_.]*)$', line)
             if m is not None:
                 if m.group(1) != 'add_header':
                     assert prev_match == 'table_apply'


### PR DESCRIPTION
…g called

So can table names, but those already seem to be handled correctly
before this change.