### PR TITLE
Change default behavior to not generate packet length errors

### DIFF
--- a/docs/p4pktgen-intro-by-example.md
+++ b/docs/p4pktgen-intro-by-example.md
@@ -52,12 +52,6 @@ There is also an `egress` control, but the current version of
 ignores the contents of the controls `DeparserImpl`, `verifyChecksum`,
 and `computeChecksum`, so we will not discuss them further.
 
-`p4pktgen` can generate packets that cause the parser to give errors,
-such as the too-short packets mentioned above.  However, that
-`p4pktgen` feature still has some issues, so we will run it with the
-command line option `-dpl` to avoid generating such packets (the long
-option name is `--disable-packet-length-errors`).
-
 ```bash
 # Start a new shell running as the super-user
 % sudo bash
@@ -65,7 +59,7 @@ option name is `--disable-packet-length-errors`).
 # Set up the shell environment variables needed for running p4pktgen
 % source my-venv/bin/activate
 
-% p4pktgen -dpl compiled_p4_programs/demo1.p4_16.json >& log1.txt
+% p4pktgen compiled_p4_programs/demo1.p4_16.json >& log1.txt
 ```
 
 Without redirecting the output to a file with the `>& log1.txt` part
@@ -189,7 +183,7 @@ our second `p4pktgen` run, to see what the results will be for this
 program.
 
 ```bash
-% p4pktgen -dpl -au compiled_p4_programs/demo1.p4_16.json >& log2.txt
+% p4pktgen -au compiled_p4_programs/demo1.p4_16.json >& log2.txt
 ```
 
 Already-generated output files from this command are stored here:
@@ -284,7 +278,7 @@ metadata field.
 To run `p4pktgen` on this program:
 
 ```bash
-% p4pktgen -dpl compiled_p4_programs/demo1-no-uninit-reads.p4_16.json >& log3.txt
+% p4pktgen compiled_p4_programs/demo1-no-uninit-reads.p4_16.json >& log3.txt
 ```
 
 Already-generated output files from this command are stored here:

--- a/docs/sample-output/log1.txt
+++ b/docs/sample-output/log1.txt
@@ -1,6 +1,3 @@
-+ /bin/rm -f test.pcap
-+ set +x
-+ p4pktgen --disable-packet-length-errors compiled_p4_programs/demo1.p4_16.json
 INFO: Found 2 parser paths, longest with length 2
 INFO: Counted 4 control paths
 INFO: path = ('start', start -> parse_ipv4) -> (u'parse_ipv4', parse_ipv4 -> sink) -> ('sink', None)

--- a/docs/sample-output/log2.txt
+++ b/docs/sample-output/log2.txt
@@ -1,6 +1,3 @@
-+ /bin/rm -f test.pcap
-+ set +x
-+ p4pktgen --disable-packet-length-errors --allow-uninitialized-reads compiled_p4_programs/demo1.p4_16.json
 INFO: Found 2 parser paths, longest with length 2
 INFO: Counted 4 control paths
 INFO: path = ('start', start -> parse_ipv4) -> (u'parse_ipv4', parse_ipv4 -> sink) -> ('sink', None)

--- a/docs/sample-output/log3.txt
+++ b/docs/sample-output/log3.txt
@@ -1,6 +1,3 @@
-+ /bin/rm -f test.pcap
-+ set +x
-+ p4pktgen --disable-packet-length-errors compiled_p4_programs/demo1-no-uninit-reads.p4_16.json
 INFO: Found 2 parser paths, longest with length 2
 INFO: Counted 7 control paths
 INFO: path = ('start', start -> parse_ipv4) -> (u'parse_ipv4', parse_ipv4 -> sink) -> ('sink', None)

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -127,10 +127,8 @@ If you see an error message like this in the output:
 
 there is a known issue where this can occur due to the way that
 execution paths through the parser are represented.  Until this
-problem is more fully fixed, you should be able to avoid it by giving
-`p4pktgen` the command line option `--disable-packet-length-errors`,
-which will cause `p4pktgen` not to create packets that exercise parser
-error cases.
+problem is more fully fixed, you should be able to avoid it by _not_
+using the command line option `--enable-packet-length-errors`.
 
 
 ## P4 programs using features not yet supported by p4pktgen

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -55,9 +55,9 @@ class Config:
         self.record_statistics = args.record_statistics
         self.allow_unimplemented_primitives = args.allow_unimplemented_primitives
         self.dump_test_case = args.dump_test_case
+        self.no_packet_length_errs = not args.enable_packet_length_errors
         # TBD: Make the values below configurable via command line
         # options.
-        self.no_packet_length_errs = args.disable_packet_length_errors
         self.min_packet_len_generated = 14
         self.max_packet_len_generated = 1536
 

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -93,13 +93,13 @@ def main():
         """With this option enabled, allow analysis of paths that use primitives not yet fully implemented.  Use of such primitives only causes warning message to be issued, and the primitive operation is treated as a no-op.  Without this option (the default), use of such primitives causes an exception to be raised, typically aborting the program at that point."""
     )
     parser.add_argument(
-        '-dpl',
-        '--disable-packet-length-errors',
-        dest='disable_packet_length_errors',
+        '-epl',
+        '--enable-packet-length-errors',
+        dest='enable_packet_length_errors',
         action='store_true',
         default=False,
         help=
-        """With this option given, do not analyze parser paths that cause errors related to packet length, such as PacketTooShort or HeaderTooShort.  Without this option (the default), do try to analyze those paths and create test packets to exercise them."""
+        """With this option given, analyze parser paths, and create test packets to exercise them, that cause errors related to packet length, such as PacketTooShort or HeaderTooShort.  Without this option (the default), do not analyze those paths, and do not create test packets for them."""
     )
     parser.add_argument(
         dest='input_file', type=str, help='Provide the path to the input file')

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -12,12 +12,12 @@
 # causing p4pktgen to fail are probably obsolete.
 
 
-#OPTS=""
+OPTS=""
 #OPTS="-d"
-#OPTS="-d --disable-packet-length-errors"
-OPTS="--disable-packet-length-errors"
+#OPTS="-d --enable-packet-length-errors"
+#OPTS="--enable-packet-length-errors"
 #OPTS="-d --dump-test-case"
-#OPTS="-d --dump-test-case --disable-packet-length-errors"
+#OPTS="-d --dump-test-case --enable-packet-length-errors"
 #OPTS="-d --allow-uninitialized-reads"
 #OPTS="-d --allow-uninitialized-reads --allow-unimplemented-primitives"
 #OPTS="--allow-uninitialized-reads --allow-unimplemented-primitives"


### PR DESCRIPTION
You can enable it with command line option --enable-packet-length-errors,
which replaces --disable-packet-length-errors, but with the opposite
effect.