### PR TITLE
Make order of printing results dict more consistent across runs

### DIFF
--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import argparse
 import json
 import logging
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import time
 
 import matplotlib.pyplot as plt
@@ -330,7 +330,7 @@ def process_json_file(input_file, debug=False, generate_graphs=False):
 
     start_time = time.time()
     count = Counter('path_count')
-    results = {}
+    results = OrderedDict()
     stats = defaultdict(int)
     last_time_printed_stats_per_control_path_edge = [time.time()]
     stats_per_control_path_edge = defaultdict(int)


### PR DESCRIPTION
This doesn't affect regression runs at all, only the order that
results are printed.  Sometimes having an updated results dict be
closer in order to an earlier one in the regression tests makes the
changes easier to compare by hand.