### PR TITLE
Add example program exercising many header stack operations

### DIFF
--- a/examples/header-stack-ops-bmv2.json
+++ b/examples/header-stack-ops-bmv2.json
@@ -474,7 +474,7 @@
       "id" : 0,
       "source_info" : {
         "filename" : "examples/header-stack-ops-bmv2.p4",
-        "line" : 222,
+        "line" : 220,
         "column" : 8,
         "source_fragment" : "DeparserI"
       },
@@ -488,8 +488,14 @@
   "learn_lists" : [],
   "actions" : [
     {
-      "name" : "act",
+      "name" : "NoAction",
       "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "act",
+      "id" : 1,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -515,59 +521,7 @@
     },
     {
       "name" : "act_0",
-      "id" : 1,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 96,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_1",
       "id" : 2,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 98,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_2",
-      "id" : 3,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -592,8 +546,8 @@
       ]
     },
     {
-      "name" : "act_3",
-      "id" : 4,
+      "name" : "act_1",
+      "id" : 3,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -618,34 +572,8 @@
       ]
     },
     {
-      "name" : "act_4",
-      "id" : 5,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 104,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_5",
-      "id" : 6,
+      "name" : "act_2",
+      "id" : 4,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -670,60 +598,8 @@
       ]
     },
     {
-      "name" : "act_6",
-      "id" : 7,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 111,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_7",
-      "id" : 8,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 113,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_8",
-      "id" : 9,
+      "name" : "act_3",
+      "id" : 5,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -748,8 +624,8 @@
       ]
     },
     {
-      "name" : "act_9",
-      "id" : 10,
+      "name" : "act_4",
+      "id" : 6,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -774,34 +650,8 @@
       ]
     },
     {
-      "name" : "act_10",
-      "id" : 11,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 119,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_11",
-      "id" : 12,
+      "name" : "act_5",
+      "id" : 7,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -898,302 +748,8 @@
       ]
     },
     {
-      "name" : "act_12",
-      "id" : 13,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[1]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 130,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 131,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 132,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 133,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 134,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_13",
-      "id" : 14,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 136,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 137,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 138,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 139,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 140,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_14",
-      "id" : 15,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[3]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 142,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 143,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 144,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 145,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 146,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_15",
-      "id" : 16,
+      "name" : "act_6",
+      "id" : 8,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -1290,8 +846,8 @@
       ]
     },
     {
-      "name" : "act_16",
-      "id" : 17,
+      "name" : "act_7",
+      "id" : 9,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -1312,8 +868,8 @@
       ]
     },
     {
-      "name" : "act_17",
-      "id" : 18,
+      "name" : "act_8",
+      "id" : 10,
       "runtime_data" : [],
       "primitives" : [
         {
@@ -1321,42 +877,392 @@
           "parameters" : [
             {
               "type" : "header",
-              "value" : "hdr_1_h2[1]"
+              "value" : "hdr_1_h2[4]"
             }
           ],
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 159,
+            "line" : 165,
             "column" : 16,
-            "source_fragment" : "hdr.h2[1].setInvalid()"
+            "source_fragment" : "hdr.h2[4].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_9",
+      "id" : 11,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign_header_stack",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "header_stack",
+              "value" : "h2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "act_10",
+      "id" : 12,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 94,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_11",
+      "id" : 13,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 100,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_12",
+      "id" : 14,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 102,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_13",
+      "id" : 15,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 109,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_14",
+      "id" : 16,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 115,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_15",
+      "id" : 17,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 117,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_16",
+      "id" : 18,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 124,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 125,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa0"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 126,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 127,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 128,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_17",
+      "id" : 19,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 148,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 149,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 150,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 151,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 152,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
           }
         }
       ]
     },
     {
       "name" : "act_18",
-      "id" : 19,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 161,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_19",
       "id" : 20,
       "runtime_data" : [],
       "primitives" : [
@@ -1365,20 +1271,20 @@
           "parameters" : [
             {
               "type" : "header",
-              "value" : "hdr_1_h2[3]"
+              "value" : "hdr_1_h2[0]"
             }
           ],
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 163,
+            "line" : 157,
             "column" : 16,
-            "source_fragment" : "hdr.h2[3].setInvalid()"
+            "source_fragment" : "hdr.h2[0].setInvalid()"
           }
         }
       ]
     },
     {
-      "name" : "act_20",
+      "name" : "act_19",
       "id" : 21,
       "runtime_data" : [],
       "primitives" : [
@@ -1400,7 +1306,7 @@
       ]
     },
     {
-      "name" : "act_21",
+      "name" : "act_20",
       "id" : 22,
       "runtime_data" : [],
       "primitives" : [
@@ -1409,934 +1315,22 @@
           "parameters" : [
             {
               "type" : "header_stack",
-              "value" : "hdr_1_h2"
+              "value" : "h2"
             },
             {
               "type" : "header_stack",
-              "value" : "h2"
+              "value" : "hdr_1_h2"
             }
           ]
         }
       ]
     },
     {
-      "name" : "act_22",
+      "name" : "act_21",
       "id" : 23,
       "runtime_data" : [],
       "primitives" : [
         {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 94,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(1)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_23",
-      "id" : 24,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 96,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_24",
-      "id" : 25,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 98,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_25",
-      "id" : 26,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 100,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(4)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_26",
-      "id" : 27,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x5"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 102,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(5)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_27",
-      "id" : 28,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 104,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_28",
-      "id" : 29,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 109,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(1)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_29",
-      "id" : 30,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 111,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_30",
-      "id" : 31,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 113,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_31",
-      "id" : 32,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 115,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(4)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_32",
-      "id" : 33,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x5"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 117,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(5)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_33",
-      "id" : 34,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 119,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_34",
-      "id" : 35,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[0]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 124,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 125,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa0"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 126,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x0a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 127,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 128,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_35",
-      "id" : 36,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[1]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 130,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 131,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 132,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 133,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 134,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_36",
-      "id" : 37,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 136,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 137,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 138,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 139,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 140,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_37",
-      "id" : 38,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[3]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 142,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 143,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 144,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 145,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 146,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_38",
-      "id" : 39,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[4]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 148,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 149,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 150,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 151,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 152,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_39",
-      "id" : 40,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[0]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 157,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_40",
-      "id" : 41,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[1]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 159,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_41",
-      "id" : 42,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 161,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_42",
-      "id" : 43,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[3]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 163,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_43",
-      "id" : 44,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[4]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 165,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_44",
-      "id" : 45,
-      "runtime_data" : [],
-      "primitives" : [
-        {
           "op" : "assign_header_stack",
           "parameters" : [
             {
@@ -2348,946 +1342,7 @@
               "value" : "hdr_1_h2"
             }
           ]
-        }
-      ]
-    },
-    {
-      "name" : "act_45",
-      "id" : 46,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 94,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(1)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_46",
-      "id" : 47,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 96,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_47",
-      "id" : 48,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 98,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_48",
-      "id" : 49,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 100,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(4)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_49",
-      "id" : 50,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x5"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 102,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(5)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_50",
-      "id" : 51,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "push",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 104,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.push_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_51",
-      "id" : 52,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 109,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(1)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_52",
-      "id" : 53,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 111,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(2)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_53",
-      "id" : 54,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 113,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(3)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_54",
-      "id" : 55,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 115,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(4)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_55",
-      "id" : 56,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x5"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 117,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(5)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_56",
-      "id" : 57,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "pop",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x6"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 119,
-            "column" : 16,
-            "source_fragment" : "hdr.h2.pop_front(6)"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_57",
-      "id" : 58,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[0]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 124,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].setValid()"
-          }
         },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 125,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa0"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 126,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x0a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 127,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 128,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_58",
-      "id" : 59,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[1]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 130,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 131,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa1"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 132,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x1a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 133,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 134,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_59",
-      "id" : 60,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 136,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 137,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa2"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 138,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x2a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 139,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 140,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_60",
-      "id" : 61,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[3]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 142,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 143,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa3"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 144,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x3a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 145,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 146,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_61",
-      "id" : 62,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "add_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[4]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 148,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].setValid()"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x02"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 149,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].hdr_type = 2"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "f1"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0xa4"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 150,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "f2"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x4a"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 151,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
-          }
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x09"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 152,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_62",
-      "id" : 63,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[0]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 157,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[0].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_63",
-      "id" : 64,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[1]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 159,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[1].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_64",
-      "id" : 65,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[2]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 161,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[2].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_65",
-      "id" : 66,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[3]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 163,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[3].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_66",
-      "id" : 67,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "remove_header",
-          "parameters" : [
-            {
-              "type" : "header",
-              "value" : "hdr_1_h2[4]"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 165,
-            "column" : 16,
-            "source_fragment" : "hdr.h2[4].setInvalid()"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_67",
-      "id" : 68,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign_header_stack",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "h2"
-            },
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name" : "act_68",
-      "id" : 69,
-      "runtime_data" : [],
-      "primitives" : [
         {
           "op" : "assign",
           "parameters" : [
@@ -3304,20 +1359,145 @@
                   "left" : {
                     "type" : "expression",
                     "value" : {
-                      "op" : "&",
+                      "op" : "|",
                       "left" : {
-                        "type" : "field",
-                        "value" : ["h1", "h2_valid_bits"]
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "|",
+                          "left" : {
+                            "type" : "expression",
+                            "value" : {
+                              "op" : "|",
+                              "left" : {
+                                "type" : "expression",
+                                "value" : {
+                                  "op" : "?",
+                                  "left" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x01"
+                                  },
+                                  "right" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x00"
+                                  },
+                                  "cond" : {
+                                    "type" : "expression",
+                                    "value" : {
+                                      "op" : "d2b",
+                                      "left" : null,
+                                      "right" : {
+                                        "type" : "field",
+                                        "value" : ["h2[0]", "$valid$"]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "right" : {
+                                "type" : "expression",
+                                "value" : {
+                                  "op" : "?",
+                                  "left" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x02"
+                                  },
+                                  "right" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x00"
+                                  },
+                                  "cond" : {
+                                    "type" : "expression",
+                                    "value" : {
+                                      "op" : "d2b",
+                                      "left" : null,
+                                      "right" : {
+                                        "type" : "field",
+                                        "value" : ["h2[1]", "$valid$"]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "right" : {
+                            "type" : "expression",
+                            "value" : {
+                              "op" : "?",
+                              "left" : {
+                                "type" : "hexstr",
+                                "value" : "0x04"
+                              },
+                              "right" : {
+                                "type" : "hexstr",
+                                "value" : "0x00"
+                              },
+                              "cond" : {
+                                "type" : "expression",
+                                "value" : {
+                                  "op" : "d2b",
+                                  "left" : null,
+                                  "right" : {
+                                    "type" : "field",
+                                    "value" : ["h2[2]", "$valid$"]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
                       },
                       "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xfe"
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "?",
+                          "left" : {
+                            "type" : "hexstr",
+                            "value" : "0x08"
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x00"
+                          },
+                          "cond" : {
+                            "type" : "expression",
+                            "value" : {
+                              "op" : "d2b",
+                              "left" : null,
+                              "right" : {
+                                "type" : "field",
+                                "value" : ["h2[3]", "$valid$"]
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   },
                   "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x01"
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "?",
+                      "left" : {
+                        "type" : "hexstr",
+                        "value" : "0x10"
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0x00"
+                      },
+                      "cond" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "d2b",
+                          "left" : null,
+                          "right" : {
+                            "type" : "field",
+                            "value" : ["h2[4]", "$valid$"]
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -3325,244 +1505,9 @@
           ],
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 186,
-            "column" : 12,
-            "source_fragment" : "hdr.h1.h2_valid_bits[0:0] = 1"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_69",
-      "id" : 70,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign_header_stack",
-          "parameters" : [
-            {
-              "type" : "header_stack",
-              "value" : "h2"
-            },
-            {
-              "type" : "header_stack",
-              "value" : "hdr_1_h2"
-            }
-          ]
-        },
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["h1", "h2_valid_bits"]
-            },
-            {
-              "type" : "hexstr",
-              "value" : "0x00"
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 184,
+            "line" : 191,
             "column" : 8,
-            "source_fragment" : "hdr.h1.h2_valid_bits = 0"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_70",
-      "id" : 71,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["h1", "h2_valid_bits"]
-            },
-            {
-              "type" : "expression",
-              "value" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "|",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "field",
-                        "value" : ["h1", "h2_valid_bits"]
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xfd"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x02"
-                  }
-                }
-              }
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 189,
-            "column" : 12,
-            "source_fragment" : "hdr.h1.h2_valid_bits[1:1] = 1"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_71",
-      "id" : 72,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["h1", "h2_valid_bits"]
-            },
-            {
-              "type" : "expression",
-              "value" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "|",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "field",
-                        "value" : ["h1", "h2_valid_bits"]
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xfb"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x04"
-                  }
-                }
-              }
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 192,
-            "column" : 12,
-            "source_fragment" : "hdr.h1.h2_valid_bits[2:2] = 1"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_72",
-      "id" : 73,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["h1", "h2_valid_bits"]
-            },
-            {
-              "type" : "expression",
-              "value" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "|",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "field",
-                        "value" : ["h1", "h2_valid_bits"]
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xf7"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x08"
-                  }
-                }
-              }
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 195,
-            "column" : 12,
-            "source_fragment" : "hdr.h1.h2_valid_bits[3:3] = 1"
-          }
-        }
-      ]
-    },
-    {
-      "name" : "act_73",
-      "id" : 74,
-      "runtime_data" : [],
-      "primitives" : [
-        {
-          "op" : "assign",
-          "parameters" : [
-            {
-              "type" : "field",
-              "value" : ["h1", "h2_valid_bits"]
-            },
-            {
-              "type" : "expression",
-              "value" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "|",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "field",
-                        "value" : ["h1", "h2_valid_bits"]
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xef"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x10"
-                  }
-                }
-              }
-            }
-          ],
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 198,
-            "column" : 12,
-            "source_fragment" : "hdr.h1.h2_valid_bits[4:4] = 1"
+            "source_fragment" : "hdr.h1.h2_valid_bits = ( ..."
           }
         }
       ]
@@ -3590,14 +1535,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [22],
-          "actions" : ["act_21"],
+          "action_ids" : [11],
+          "actions" : ["act_9"],
           "base_default_next" : "node_3",
           "next_tables" : {
-            "act_21" : "node_3"
+            "act_9" : "node_3"
           },
           "default_entry" : {
-            "action_id" : 22,
+            "action_id" : 11,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3613,14 +1558,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [0],
+          "action_ids" : [1],
           "actions" : ["act"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act" : "tbl_act_22"
+            "act" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 0,
+            "action_id" : 1,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3636,14 +1581,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [1],
+          "action_ids" : [2],
           "actions" : ["act_0"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_0" : "tbl_act_22"
+            "act_0" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 1,
+            "action_id" : 2,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3659,14 +1604,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [2],
+          "action_ids" : [3],
           "actions" : ["act_1"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_1" : "tbl_act_22"
+            "act_1" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 2,
+            "action_id" : 3,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3682,14 +1627,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [3],
+          "action_ids" : [4],
           "actions" : ["act_2"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_2" : "tbl_act_22"
+            "act_2" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 3,
+            "action_id" : 4,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3705,14 +1650,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [4],
+          "action_ids" : [5],
           "actions" : ["act_3"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_3" : "tbl_act_22"
+            "act_3" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 4,
+            "action_id" : 5,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3728,14 +1673,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [5],
+          "action_ids" : [6],
           "actions" : ["act_4"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_4" : "tbl_act_22"
+            "act_4" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 5,
+            "action_id" : 6,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3751,14 +1696,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [6],
+          "action_ids" : [7],
           "actions" : ["act_5"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_5" : "tbl_act_22"
+            "act_5" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 6,
+            "action_id" : 7,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3774,14 +1719,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [7],
+          "action_ids" : [8],
           "actions" : ["act_6"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_6" : "tbl_act_22"
+            "act_6" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 7,
+            "action_id" : 8,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3797,14 +1742,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [8],
+          "action_ids" : [9],
           "actions" : ["act_7"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_7" : "tbl_act_22"
+            "act_7" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 8,
+            "action_id" : 9,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3820,14 +1765,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [9],
+          "action_ids" : [10],
           "actions" : ["act_8"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_10",
           "next_tables" : {
-            "act_8" : "tbl_act_22"
+            "act_8" : "tbl_act_10"
           },
           "default_entry" : {
-            "action_id" : 9,
+            "action_id" : 10,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3843,14 +1788,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [10],
-          "actions" : ["act_9"],
-          "base_default_next" : "tbl_act_22",
+          "action_ids" : [22],
+          "actions" : ["act_20"],
+          "base_default_next" : "node_29",
           "next_tables" : {
-            "act_9" : "tbl_act_22"
+            "act_20" : "node_29"
           },
           "default_entry" : {
-            "action_id" : 10,
+            "action_id" : 22,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3866,14 +1811,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [11],
+          "action_ids" : [12],
           "actions" : ["act_10"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_10" : "tbl_act_22"
+            "act_10" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 11,
+            "action_id" : 12,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3889,14 +1834,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [12],
+          "action_ids" : [13],
           "actions" : ["act_11"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_11" : "tbl_act_22"
+            "act_11" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 12,
+            "action_id" : 13,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3912,14 +1857,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [13],
+          "action_ids" : [14],
           "actions" : ["act_12"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_12" : "tbl_act_22"
+            "act_12" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 13,
+            "action_id" : 14,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3935,14 +1880,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [14],
+          "action_ids" : [15],
           "actions" : ["act_13"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_13" : "tbl_act_22"
+            "act_13" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 14,
+            "action_id" : 15,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3958,14 +1903,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [15],
+          "action_ids" : [16],
           "actions" : ["act_14"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_14" : "tbl_act_22"
+            "act_14" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 15,
+            "action_id" : 16,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -3981,14 +1926,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [16],
+          "action_ids" : [17],
           "actions" : ["act_15"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_15" : "tbl_act_22"
+            "act_15" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 16,
+            "action_id" : 17,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -4004,14 +1949,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [17],
+          "action_ids" : [18],
           "actions" : ["act_16"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_16" : "tbl_act_22"
+            "act_16" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 17,
+            "action_id" : 18,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -4027,14 +1972,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [18],
+          "action_ids" : [19],
           "actions" : ["act_17"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_17" : "tbl_act_22"
+            "act_17" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 18,
+            "action_id" : 19,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -4050,14 +1995,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [19],
+          "action_ids" : [20],
           "actions" : ["act_18"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_18" : "tbl_act_22"
+            "act_18" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 19,
+            "action_id" : 20,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -4073,14 +2018,14 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [20],
+          "action_ids" : [21],
           "actions" : ["act_19"],
-          "base_default_next" : "tbl_act_22",
+          "base_default_next" : "tbl_act_21",
           "next_tables" : {
-            "act_19" : "tbl_act_22"
+            "act_19" : "tbl_act_21"
           },
           "default_entry" : {
-            "action_id" : 20,
+            "action_id" : 21,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -4096,57 +2041,11 @@
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [21],
-          "actions" : ["act_20"],
-          "base_default_next" : "tbl_act_22",
-          "next_tables" : {
-            "act_20" : "tbl_act_22"
-          },
-          "default_entry" : {
-            "action_id" : 21,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_22",
-          "id" : 23,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [45],
-          "actions" : ["act_44"],
-          "base_default_next" : "node_53",
-          "next_tables" : {
-            "act_44" : "node_53"
-          },
-          "default_entry" : {
-            "action_id" : 45,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_23",
-          "id" : 24,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
           "action_ids" : [23],
-          "actions" : ["act_22"],
-          "base_default_next" : "tbl_act_45",
+          "actions" : ["act_21"],
+          "base_default_next" : "debug_h2_valid_bits",
           "next_tables" : {
-            "act_22" : "tbl_act_45"
+            "act_21" : "debug_h2_valid_bits"
           },
           "default_entry" : {
             "action_id" : 23,
@@ -4156,1150 +2055,35 @@
           }
         },
         {
-          "name" : "tbl_act_24",
-          "id" : 25,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [24],
-          "actions" : ["act_23"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_23" : "tbl_act_45"
+          "name" : "debug_h2_valid_bits",
+          "id" : 23,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 176,
+            "column" : 10,
+            "source_fragment" : "debug_h2_valid_bits"
           },
-          "default_entry" : {
-            "action_id" : 24,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_25",
-          "id" : 26,
-          "key" : [],
+          "key" : [
+            {
+              "match_type" : "exact",
+              "target" : ["h1", "h2_valid_bits"],
+              "mask" : null
+            }
+          ],
           "match_type" : "exact",
           "type" : "simple",
           "max_size" : 1024,
           "with_counters" : false,
           "support_timeout" : false,
           "direct_meters" : null,
-          "action_ids" : [25],
-          "actions" : ["act_24"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_24" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 25,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_26",
-          "id" : 27,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [26],
-          "actions" : ["act_25"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_25" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 26,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_27",
-          "id" : 28,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [27],
-          "actions" : ["act_26"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_26" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 27,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_28",
-          "id" : 29,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [28],
-          "actions" : ["act_27"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_27" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 28,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_29",
-          "id" : 30,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [29],
-          "actions" : ["act_28"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_28" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 29,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_30",
-          "id" : 31,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [30],
-          "actions" : ["act_29"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_29" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 30,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_31",
-          "id" : 32,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [31],
-          "actions" : ["act_30"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_30" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 31,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_32",
-          "id" : 33,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [32],
-          "actions" : ["act_31"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_31" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 32,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_33",
-          "id" : 34,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [33],
-          "actions" : ["act_32"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_32" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 33,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_34",
-          "id" : 35,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [34],
-          "actions" : ["act_33"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_33" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 34,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_35",
-          "id" : 36,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [35],
-          "actions" : ["act_34"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_34" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 35,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_36",
-          "id" : 37,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [36],
-          "actions" : ["act_35"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_35" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 36,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_37",
-          "id" : 38,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [37],
-          "actions" : ["act_36"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_36" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 37,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_38",
-          "id" : 39,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [38],
-          "actions" : ["act_37"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_37" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 38,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_39",
-          "id" : 40,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [39],
-          "actions" : ["act_38"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_38" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 39,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_40",
-          "id" : 41,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [40],
-          "actions" : ["act_39"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_39" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 40,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_41",
-          "id" : 42,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [41],
-          "actions" : ["act_40"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_40" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 41,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_42",
-          "id" : 43,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [42],
-          "actions" : ["act_41"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_41" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 42,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_43",
-          "id" : 44,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [43],
-          "actions" : ["act_42"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_42" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 43,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_44",
-          "id" : 45,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [44],
-          "actions" : ["act_43"],
-          "base_default_next" : "tbl_act_45",
-          "next_tables" : {
-            "act_43" : "tbl_act_45"
-          },
-          "default_entry" : {
-            "action_id" : 44,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_45",
-          "id" : 46,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [68],
-          "actions" : ["act_67"],
-          "base_default_next" : "node_103",
-          "next_tables" : {
-            "act_67" : "node_103"
-          },
-          "default_entry" : {
-            "action_id" : 68,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_46",
-          "id" : 47,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [46],
-          "actions" : ["act_45"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_45" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 46,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_47",
-          "id" : 48,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [47],
-          "actions" : ["act_46"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_46" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 47,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_48",
-          "id" : 49,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [48],
-          "actions" : ["act_47"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_47" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 48,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_49",
-          "id" : 50,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [49],
-          "actions" : ["act_48"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_48" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 49,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_50",
-          "id" : 51,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [50],
-          "actions" : ["act_49"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_49" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 50,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_51",
-          "id" : 52,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [51],
-          "actions" : ["act_50"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_50" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 51,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_52",
-          "id" : 53,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [52],
-          "actions" : ["act_51"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_51" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 52,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_53",
-          "id" : 54,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [53],
-          "actions" : ["act_52"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_52" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 53,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_54",
-          "id" : 55,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [54],
-          "actions" : ["act_53"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_53" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 54,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_55",
-          "id" : 56,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [55],
-          "actions" : ["act_54"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_54" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 55,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_56",
-          "id" : 57,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [56],
-          "actions" : ["act_55"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_55" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 56,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_57",
-          "id" : 58,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [57],
-          "actions" : ["act_56"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_56" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 57,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_58",
-          "id" : 59,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [58],
-          "actions" : ["act_57"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_57" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 58,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_59",
-          "id" : 60,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [59],
-          "actions" : ["act_58"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_58" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 59,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_60",
-          "id" : 61,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [60],
-          "actions" : ["act_59"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_59" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 60,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_61",
-          "id" : 62,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [61],
-          "actions" : ["act_60"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_60" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 61,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_62",
-          "id" : 63,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [62],
-          "actions" : ["act_61"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_61" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 62,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_63",
-          "id" : 64,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [63],
-          "actions" : ["act_62"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_62" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 63,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_64",
-          "id" : 65,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [64],
-          "actions" : ["act_63"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_63" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 64,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_65",
-          "id" : 66,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [65],
-          "actions" : ["act_64"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_64" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 65,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_66",
-          "id" : 67,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [66],
-          "actions" : ["act_65"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_65" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 66,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_67",
-          "id" : 68,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [67],
-          "actions" : ["act_66"],
-          "base_default_next" : "tbl_act_68",
-          "next_tables" : {
-            "act_66" : "tbl_act_68"
-          },
-          "default_entry" : {
-            "action_id" : 67,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_68",
-          "id" : 69,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [70],
-          "actions" : ["act_69"],
-          "base_default_next" : "node_153",
-          "next_tables" : {
-            "act_69" : "node_153"
-          },
-          "default_entry" : {
-            "action_id" : 70,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_69",
-          "id" : 70,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [69],
-          "actions" : ["act_68"],
-          "base_default_next" : "node_155",
-          "next_tables" : {
-            "act_68" : "node_155"
-          },
-          "default_entry" : {
-            "action_id" : 69,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_70",
-          "id" : 71,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [71],
-          "actions" : ["act_70"],
-          "base_default_next" : "node_157",
-          "next_tables" : {
-            "act_70" : "node_157"
-          },
-          "default_entry" : {
-            "action_id" : 71,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_71",
-          "id" : 72,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [72],
-          "actions" : ["act_71"],
-          "base_default_next" : "node_159",
-          "next_tables" : {
-            "act_71" : "node_159"
-          },
-          "default_entry" : {
-            "action_id" : 72,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_72",
-          "id" : 73,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [73],
-          "actions" : ["act_72"],
-          "base_default_next" : "node_161",
-          "next_tables" : {
-            "act_72" : "node_161"
-          },
-          "default_entry" : {
-            "action_id" : 73,
-            "action_const" : true,
-            "action_data" : [],
-            "action_entry_const" : true
-          }
-        },
-        {
-          "name" : "tbl_act_73",
-          "id" : 74,
-          "key" : [],
-          "match_type" : "exact",
-          "type" : "simple",
-          "max_size" : 1024,
-          "with_counters" : false,
-          "support_timeout" : false,
-          "direct_meters" : null,
-          "action_ids" : [74],
-          "actions" : ["act_73"],
+          "action_ids" : [0],
+          "actions" : ["NoAction"],
           "base_default_next" : null,
           "next_tables" : {
-            "act_73" : null
+            "NoAction" : null
           },
           "default_entry" : {
-            "action_id" : 74,
+            "action_id" : 0,
             "action_const" : true,
             "action_data" : [],
             "action_entry_const" : true
@@ -5332,7 +2116,7 @@
             }
           },
           "false_next" : "node_4",
-          "true_next" : "tbl_act_22"
+          "true_next" : "tbl_act_10"
         },
         {
           "name" : "node_4",
@@ -5388,7 +2172,7 @@
             }
           },
           "true_next" : "node_5",
-          "false_next" : "node_17"
+          "false_next" : "node_11"
         },
         {
           "name" : "node_5",
@@ -5431,78 +2215,6 @@
           "id" : 3,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 95,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_1",
-          "false_next" : "node_9"
-        },
-        {
-          "name" : "node_9",
-          "id" : 4,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 97,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_2",
-          "false_next" : "node_11"
-        },
-        {
-          "name" : "node_11",
-          "id" : 5,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 99,
             "column" : 23,
             "source_fragment" : "op[3:0] == 4"
@@ -5531,12 +2243,12 @@
               }
             }
           },
-          "true_next" : "tbl_act_3",
-          "false_next" : "node_13"
+          "true_next" : "tbl_act_1",
+          "false_next" : "node_9"
         },
         {
-          "name" : "node_13",
-          "id" : 6,
+          "name" : "node_9",
+          "id" : 4,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 101,
@@ -5567,48 +2279,12 @@
               }
             }
           },
-          "true_next" : "tbl_act_4",
-          "false_next" : "node_15"
+          "true_next" : "tbl_act_2",
+          "false_next" : "tbl_act_10"
         },
         {
-          "name" : "node_15",
-          "id" : 7,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 103,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_5",
-          "false_next" : "tbl_act_22"
-        },
-        {
-          "name" : "node_17",
-          "id" : 8,
+          "name" : "node_11",
+          "id" : 5,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 106,
@@ -5659,12 +2335,12 @@
               }
             }
           },
-          "true_next" : "node_18",
-          "false_next" : "node_30"
+          "true_next" : "node_12",
+          "false_next" : "node_18"
         },
         {
-          "name" : "node_18",
-          "id" : 9,
+          "name" : "node_12",
+          "id" : 6,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 108,
@@ -5695,17 +2371,17 @@
               }
             }
           },
-          "true_next" : "tbl_act_6",
-          "false_next" : "node_20"
+          "true_next" : "tbl_act_3",
+          "false_next" : "node_14"
         },
         {
-          "name" : "node_20",
-          "id" : 10,
+          "name" : "node_14",
+          "id" : 7,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 110,
+            "line" : 114,
             "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
+            "source_fragment" : "op[3:0] == 4"
           },
           "expression" : {
             "type" : "expression",
@@ -5727,21 +2403,21 @@
               },
               "right" : {
                 "type" : "hexstr",
-                "value" : "0x02"
+                "value" : "0x04"
               }
             }
           },
-          "true_next" : "tbl_act_7",
-          "false_next" : "node_22"
+          "true_next" : "tbl_act_4",
+          "false_next" : "node_16"
         },
         {
-          "name" : "node_22",
-          "id" : 11,
+          "name" : "node_16",
+          "id" : 8,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 112,
+            "line" : 116,
             "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
+            "source_fragment" : "op[3:0] == 5"
           },
           "expression" : {
             "type" : "expression",
@@ -5754,6 +2430,62 @@
                   "left" : {
                     "type" : "field",
                     "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_5",
+          "false_next" : "tbl_act_10"
+        },
+        {
+          "name" : "node_18",
+          "id" : 9,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 121,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
                   },
                   "right" : {
                     "type" : "hexstr",
@@ -5767,15 +2499,179 @@
               }
             }
           },
-          "true_next" : "tbl_act_8",
-          "false_next" : "node_24"
+          "true_next" : "node_19",
+          "false_next" : "node_23"
         },
         {
-          "name" : "node_24",
+          "name" : "node_19",
+          "id" : 10,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 123,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_6",
+          "false_next" : "node_21"
+        },
+        {
+          "name" : "node_21",
+          "id" : 11,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 147,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_7",
+          "false_next" : "tbl_act_10"
+        },
+        {
+          "name" : "node_23",
           "id" : 12,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 114,
+            "line" : 154,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "node_24",
+          "false_next" : "tbl_act_10"
+        },
+        {
+          "name" : "node_24",
+          "id" : 13,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 156,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_8",
+          "false_next" : "node_26"
+        },
+        {
+          "name" : "node_26",
+          "id" : 14,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 164,
             "column" : 23,
             "source_fragment" : "op[3:0] == 4"
           },
@@ -5804,555 +2700,11 @@
             }
           },
           "true_next" : "tbl_act_9",
-          "false_next" : "node_26"
+          "false_next" : "tbl_act_10"
         },
         {
-          "name" : "node_26",
-          "id" : 13,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 116,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 5"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x05"
-              }
-            }
-          },
-          "true_next" : "tbl_act_10",
-          "false_next" : "node_28"
-        },
-        {
-          "name" : "node_28",
-          "id" : 14,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 118,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_11",
-          "false_next" : "tbl_act_22"
-        },
-        {
-          "name" : "node_30",
+          "name" : "node_29",
           "id" : 15,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 121,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op1"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "node_31",
-          "false_next" : "node_41"
-        },
-        {
-          "name" : "node_31",
-          "id" : 16,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 123,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_12",
-          "false_next" : "node_33"
-        },
-        {
-          "name" : "node_33",
-          "id" : 17,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 129,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_13",
-          "false_next" : "node_35"
-        },
-        {
-          "name" : "node_35",
-          "id" : 18,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 135,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_14",
-          "false_next" : "node_37"
-        },
-        {
-          "name" : "node_37",
-          "id" : 19,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 141,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_15",
-          "false_next" : "node_39"
-        },
-        {
-          "name" : "node_39",
-          "id" : 20,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 147,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_16",
-          "false_next" : "tbl_act_22"
-        },
-        {
-          "name" : "node_41",
-          "id" : 21,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 154,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op1"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "node_42",
-          "false_next" : "tbl_act_22"
-        },
-        {
-          "name" : "node_42",
-          "id" : 22,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 156,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_17",
-          "false_next" : "node_44"
-        },
-        {
-          "name" : "node_44",
-          "id" : 23,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 158,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_18",
-          "false_next" : "node_46"
-        },
-        {
-          "name" : "node_46",
-          "id" : 24,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 160,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_19",
-          "false_next" : "node_48"
-        },
-        {
-          "name" : "node_48",
-          "id" : 25,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 162,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_20",
-          "false_next" : "node_50"
-        },
-        {
-          "name" : "node_50",
-          "id" : 26,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 164,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op1"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_21",
-          "false_next" : "tbl_act_22"
-        },
-        {
-          "name" : "node_53",
-          "id" : 27,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 89,
@@ -6373,17 +2725,529 @@
               }
             }
           },
-          "false_next" : "node_54",
-          "true_next" : "tbl_act_45"
+          "false_next" : "node_30",
+          "true_next" : "tbl_act_21"
         },
         {
-          "name" : "node_54",
+          "name" : "node_30",
+          "id" : 16,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 91,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "node_31",
+          "false_next" : "node_37"
+        },
+        {
+          "name" : "node_31",
+          "id" : 17,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 93,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_11",
+          "false_next" : "node_33"
+        },
+        {
+          "name" : "node_33",
+          "id" : 18,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 99,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_12",
+          "false_next" : "node_35"
+        },
+        {
+          "name" : "node_35",
+          "id" : 19,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 101,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_13",
+          "false_next" : "tbl_act_21"
+        },
+        {
+          "name" : "node_37",
+          "id" : 20,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 106,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "node_38",
+          "false_next" : "node_44"
+        },
+        {
+          "name" : "node_38",
+          "id" : 21,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 108,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_14",
+          "false_next" : "node_40"
+        },
+        {
+          "name" : "node_40",
+          "id" : 22,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 114,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_15",
+          "false_next" : "node_42"
+        },
+        {
+          "name" : "node_42",
+          "id" : 23,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 116,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_16",
+          "false_next" : "tbl_act_21"
+        },
+        {
+          "name" : "node_44",
+          "id" : 24,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 121,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "node_45",
+          "false_next" : "node_49"
+        },
+        {
+          "name" : "node_45",
+          "id" : 25,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 123,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_17",
+          "false_next" : "node_47"
+        },
+        {
+          "name" : "node_47",
+          "id" : 26,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 147,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_18",
+          "false_next" : "tbl_act_21"
+        },
+        {
+          "name" : "node_49",
+          "id" : 27,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 154,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "node_50",
+          "false_next" : "tbl_act_21"
+        },
+        {
+          "name" : "node_50",
           "id" : 28,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 91,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 1"
+            "line" : 156,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
           },
           "expression" : {
             "type" : "expression",
@@ -6394,28 +3258,8 @@
                 "value" : {
                   "op" : "&",
                   "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op2"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
                   },
                   "right" : {
                     "type" : "hexstr",
@@ -6425,942 +3269,18 @@
               },
               "right" : {
                 "type" : "hexstr",
-                "value" : "0x01"
+                "value" : "0x00"
               }
             }
           },
-          "true_next" : "node_55",
-          "false_next" : "node_67"
+          "true_next" : "tbl_act_19",
+          "false_next" : "node_52"
         },
         {
-          "name" : "node_55",
+          "name" : "node_52",
           "id" : 29,
           "source_info" : {
             "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 93,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_23",
-          "false_next" : "node_57"
-        },
-        {
-          "name" : "node_57",
-          "id" : 30,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 95,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_24",
-          "false_next" : "node_59"
-        },
-        {
-          "name" : "node_59",
-          "id" : 31,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 97,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_25",
-          "false_next" : "node_61"
-        },
-        {
-          "name" : "node_61",
-          "id" : 32,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 99,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_26",
-          "false_next" : "node_63"
-        },
-        {
-          "name" : "node_63",
-          "id" : 33,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 101,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 5"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x05"
-              }
-            }
-          },
-          "true_next" : "tbl_act_27",
-          "false_next" : "node_65"
-        },
-        {
-          "name" : "node_65",
-          "id" : 34,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 103,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_28",
-          "false_next" : "tbl_act_45"
-        },
-        {
-          "name" : "node_67",
-          "id" : 35,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 106,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op2"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "node_68",
-          "false_next" : "node_80"
-        },
-        {
-          "name" : "node_68",
-          "id" : 36,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 108,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_29",
-          "false_next" : "node_70"
-        },
-        {
-          "name" : "node_70",
-          "id" : 37,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 110,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_30",
-          "false_next" : "node_72"
-        },
-        {
-          "name" : "node_72",
-          "id" : 38,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 112,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_31",
-          "false_next" : "node_74"
-        },
-        {
-          "name" : "node_74",
-          "id" : 39,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 114,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_32",
-          "false_next" : "node_76"
-        },
-        {
-          "name" : "node_76",
-          "id" : 40,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 116,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 5"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x05"
-              }
-            }
-          },
-          "true_next" : "tbl_act_33",
-          "false_next" : "node_78"
-        },
-        {
-          "name" : "node_78",
-          "id" : 41,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 118,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_34",
-          "false_next" : "tbl_act_45"
-        },
-        {
-          "name" : "node_80",
-          "id" : 42,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 121,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op2"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "node_81",
-          "false_next" : "node_91"
-        },
-        {
-          "name" : "node_81",
-          "id" : 43,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 123,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_35",
-          "false_next" : "node_83"
-        },
-        {
-          "name" : "node_83",
-          "id" : 44,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 129,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_36",
-          "false_next" : "node_85"
-        },
-        {
-          "name" : "node_85",
-          "id" : 45,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 135,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_37",
-          "false_next" : "node_87"
-        },
-        {
-          "name" : "node_87",
-          "id" : 46,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 141,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_38",
-          "false_next" : "node_89"
-        },
-        {
-          "name" : "node_89",
-          "id" : 47,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 147,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_39",
-          "false_next" : "tbl_act_45"
-        },
-        {
-          "name" : "node_91",
-          "id" : 48,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 154,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op2"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "node_92",
-          "false_next" : "tbl_act_45"
-        },
-        {
-          "name" : "node_92",
-          "id" : 49,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 156,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_40",
-          "false_next" : "node_94"
-        },
-        {
-          "name" : "node_94",
-          "id" : 50,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 158,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_41",
-          "false_next" : "node_96"
-        },
-        {
-          "name" : "node_96",
-          "id" : 51,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 160,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_42",
-          "false_next" : "node_98"
-        },
-        {
-          "name" : "node_98",
-          "id" : 52,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 162,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op2"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_43",
-          "false_next" : "node_100"
-        },
-        {
-          "name" : "node_100",
-          "id" : 53,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
             "line" : 164,
             "column" : 23,
             "source_fragment" : "op[3:0] == 4"
@@ -7389,1165 +3309,8 @@
               }
             }
           },
-          "true_next" : "tbl_act_44",
-          "false_next" : "tbl_act_45"
-        },
-        {
-          "name" : "node_103",
-          "id" : 54,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 89,
-            "column" : 12,
-            "source_fragment" : "op == 0x00"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "field",
-                "value" : ["h1", "op3"]
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "false_next" : "node_104",
-          "true_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_104",
-          "id" : 55,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 91,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op3"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "node_105",
-          "false_next" : "node_117"
-        },
-        {
-          "name" : "node_105",
-          "id" : 56,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 93,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_46",
-          "false_next" : "node_107"
-        },
-        {
-          "name" : "node_107",
-          "id" : 57,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 95,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_47",
-          "false_next" : "node_109"
-        },
-        {
-          "name" : "node_109",
-          "id" : 58,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 97,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_48",
-          "false_next" : "node_111"
-        },
-        {
-          "name" : "node_111",
-          "id" : 59,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 99,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_49",
-          "false_next" : "node_113"
-        },
-        {
-          "name" : "node_113",
-          "id" : 60,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 101,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 5"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x05"
-              }
-            }
-          },
-          "true_next" : "tbl_act_50",
-          "false_next" : "node_115"
-        },
-        {
-          "name" : "node_115",
-          "id" : 61,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 103,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_51",
-          "false_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_117",
-          "id" : 62,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 106,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op3"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "node_118",
-          "false_next" : "node_130"
-        },
-        {
-          "name" : "node_118",
-          "id" : 63,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 108,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_52",
-          "false_next" : "node_120"
-        },
-        {
-          "name" : "node_120",
-          "id" : 64,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 110,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_53",
-          "false_next" : "node_122"
-        },
-        {
-          "name" : "node_122",
-          "id" : 65,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 112,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_54",
-          "false_next" : "node_124"
-        },
-        {
-          "name" : "node_124",
-          "id" : 66,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 114,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_55",
-          "false_next" : "node_126"
-        },
-        {
-          "name" : "node_126",
-          "id" : 67,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 116,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 5"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x05"
-              }
-            }
-          },
-          "true_next" : "tbl_act_56",
-          "false_next" : "node_128"
-        },
-        {
-          "name" : "node_128",
-          "id" : 68,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 118,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 6"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x06"
-              }
-            }
-          },
-          "true_next" : "tbl_act_57",
-          "false_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_130",
-          "id" : 69,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 121,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op3"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "node_131",
-          "false_next" : "node_141"
-        },
-        {
-          "name" : "node_131",
-          "id" : 70,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 123,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_58",
-          "false_next" : "node_133"
-        },
-        {
-          "name" : "node_133",
-          "id" : 71,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 129,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_59",
-          "false_next" : "node_135"
-        },
-        {
-          "name" : "node_135",
-          "id" : 72,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 135,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_60",
-          "false_next" : "node_137"
-        },
-        {
-          "name" : "node_137",
-          "id" : 73,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 141,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_61",
-          "false_next" : "node_139"
-        },
-        {
-          "name" : "node_139",
-          "id" : 74,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 147,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_62",
-          "false_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_141",
-          "id" : 75,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 154,
-            "column" : 19,
-            "source_fragment" : "op[7:4] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "expression",
-                    "value" : {
-                      "op" : "&",
-                      "left" : {
-                        "type" : "expression",
-                        "value" : {
-                          "op" : ">>",
-                          "left" : {
-                            "type" : "field",
-                            "value" : ["h1", "op3"]
-                          },
-                          "right" : {
-                            "type" : "hexstr",
-                            "value" : "0x4"
-                          }
-                        }
-                      },
-                      "right" : {
-                        "type" : "hexstr",
-                        "value" : "0xff"
-                      }
-                    }
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "node_142",
-          "false_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_142",
-          "id" : 76,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 156,
-            "column" : 16,
-            "source_fragment" : "op[3:0] == 0"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x00"
-              }
-            }
-          },
-          "true_next" : "tbl_act_63",
-          "false_next" : "node_144"
-        },
-        {
-          "name" : "node_144",
-          "id" : 77,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 158,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 1"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x01"
-              }
-            }
-          },
-          "true_next" : "tbl_act_64",
-          "false_next" : "node_146"
-        },
-        {
-          "name" : "node_146",
-          "id" : 78,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 160,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 2"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x02"
-              }
-            }
-          },
-          "true_next" : "tbl_act_65",
-          "false_next" : "node_148"
-        },
-        {
-          "name" : "node_148",
-          "id" : 79,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 162,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 3"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x03"
-              }
-            }
-          },
-          "true_next" : "tbl_act_66",
-          "false_next" : "node_150"
-        },
-        {
-          "name" : "node_150",
-          "id" : 80,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 164,
-            "column" : 23,
-            "source_fragment" : "op[3:0] == 4"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "==",
-              "left" : {
-                "type" : "expression",
-                "value" : {
-                  "op" : "&",
-                  "left" : {
-                    "type" : "field",
-                    "value" : ["h1", "op3"]
-                  },
-                  "right" : {
-                    "type" : "hexstr",
-                    "value" : "0x0f"
-                  }
-                }
-              },
-              "right" : {
-                "type" : "hexstr",
-                "value" : "0x04"
-              }
-            }
-          },
-          "true_next" : "tbl_act_67",
-          "false_next" : "tbl_act_68"
-        },
-        {
-          "name" : "node_153",
-          "id" : 81,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 185,
-            "column" : 12,
-            "source_fragment" : "hdr.h2[0].isValid()"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "d2b",
-              "left" : null,
-              "right" : {
-                "type" : "field",
-                "value" : ["h2[0]", "$valid$"]
-              }
-            }
-          },
-          "true_next" : "tbl_act_69",
-          "false_next" : "node_155"
-        },
-        {
-          "name" : "node_155",
-          "id" : 82,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 188,
-            "column" : 12,
-            "source_fragment" : "hdr.h2[1].isValid()"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "d2b",
-              "left" : null,
-              "right" : {
-                "type" : "field",
-                "value" : ["h2[1]", "$valid$"]
-              }
-            }
-          },
-          "true_next" : "tbl_act_70",
-          "false_next" : "node_157"
-        },
-        {
-          "name" : "node_157",
-          "id" : 83,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 191,
-            "column" : 12,
-            "source_fragment" : "hdr.h2[2].isValid()"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "d2b",
-              "left" : null,
-              "right" : {
-                "type" : "field",
-                "value" : ["h2[2]", "$valid$"]
-              }
-            }
-          },
-          "true_next" : "tbl_act_71",
-          "false_next" : "node_159"
-        },
-        {
-          "name" : "node_159",
-          "id" : 84,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 194,
-            "column" : 12,
-            "source_fragment" : "hdr.h2[3].isValid()"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "d2b",
-              "left" : null,
-              "right" : {
-                "type" : "field",
-                "value" : ["h2[3]", "$valid$"]
-              }
-            }
-          },
-          "true_next" : "tbl_act_72",
-          "false_next" : "node_161"
-        },
-        {
-          "name" : "node_161",
-          "id" : 85,
-          "source_info" : {
-            "filename" : "examples/header-stack-ops-bmv2.p4",
-            "line" : 197,
-            "column" : 12,
-            "source_fragment" : "hdr.h2[4].isValid()"
-          },
-          "expression" : {
-            "type" : "expression",
-            "value" : {
-              "op" : "d2b",
-              "left" : null,
-              "right" : {
-                "type" : "field",
-                "value" : ["h2[4]", "$valid$"]
-              }
-            }
-          },
-          "false_next" : null,
-          "true_next" : "tbl_act_73"
+          "true_next" : "tbl_act_20",
+          "false_next" : "tbl_act_21"
         }
       ]
     },
@@ -8556,7 +3319,7 @@
       "id" : 1,
       "source_info" : {
         "filename" : "examples/header-stack-ops-bmv2.p4",
-        "line" : 203,
+        "line" : 201,
         "column" : 8,
         "source_fragment" : "cEgress"
       },

--- a/examples/header-stack-ops-bmv2.json
+++ b/examples/header-stack-ops-bmv2.json
@@ -1,0 +1,8610 @@
+{
+  "program" : "examples/header-stack-ops-bmv2.p4",
+  "__meta__" : {
+    "version" : [2, 7],
+    "compiler" : "https://github.com/p4lang/p4c"
+  },
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 1, false],
+        ["tmp_0", 1, false],
+        ["tmp_1", 1, false],
+        ["_padding_0", 5, false]
+      ]
+    },
+    {
+      "name" : "h2_t",
+      "id" : 1,
+      "fields" : [
+        ["hdr_type", 8, false],
+        ["f1", 8, false],
+        ["f2", 8, false],
+        ["next_hdr_type", 8, false]
+      ]
+    },
+    {
+      "name" : "h1_t",
+      "id" : 2,
+      "fields" : [
+        ["hdr_type", 8, false],
+        ["op1", 8, false],
+        ["op2", 8, false],
+        ["op3", 8, false],
+        ["h2_valid_bits", 8, false],
+        ["next_hdr_type", 8, false]
+      ]
+    },
+    {
+      "name" : "h3_t",
+      "id" : 3,
+      "fields" : [
+        ["hdr_type", 8, false],
+        ["data", 8, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 4,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["clone_spec", 32, false],
+        ["instance_type", 32, false],
+        ["drop", 1, false],
+        ["recirculate_port", 16, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["lf_field_list", 32, false],
+        ["mcast_grp", 16, false],
+        ["resubmit_flag", 1, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["_padding", 4, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "hdr_1_h2[0]",
+      "id" : 0,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr_1_h2[1]",
+      "id" : 1,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr_1_h2[2]",
+      "id" : 2,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr_1_h2[3]",
+      "id" : 3,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr_1_h2[4]",
+      "id" : 4,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "scalars",
+      "id" : 5,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 6,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h1",
+      "id" : 7,
+      "header_type" : "h1_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h3",
+      "id" : 8,
+      "header_type" : "h3_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h2[0]",
+      "id" : 9,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h2[1]",
+      "id" : 10,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h2[2]",
+      "id" : 11,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h2[3]",
+      "id" : 12,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "h2[4]",
+      "id" : 13,
+      "header_type" : "h2_t",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "hdr_1_h2",
+      "id" : 0,
+      "header_type" : "h2_t",
+      "size" : 5,
+      "header_ids" : [0, 1, 2, 3, 4]
+    },
+    {
+      "name" : "h2",
+      "id" : 1,
+      "header_type" : "h2_t",
+      "size" : 5,
+      "header_ids" : [9, 10, 11, 12, 13]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6],
+    ["BadHeaderType", 7]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "h1"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "b2d",
+                      "left" : null,
+                      "right" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "==",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "hdr_type"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x01"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "op" : "d2b",
+                    "left" : null,
+                    "right" : {
+                      "type" : "field",
+                      "value" : ["scalars", "tmp"]
+                    }
+                  }
+                },
+                {
+                  "type" : "hexstr",
+                  "value" : "7"
+                }
+              ],
+              "op" : "verify"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "0x02",
+              "mask" : null,
+              "next_state" : "parse_h2"
+            },
+            {
+              "value" : "0x03",
+              "mask" : null,
+              "next_state" : "parse_h3"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "next_hdr_type"]
+            }
+          ]
+        },
+        {
+          "name" : "parse_h2",
+          "id" : 1,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "h2"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_0"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "b2d",
+                      "left" : null,
+                      "right" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "==",
+                          "left" : {
+                            "type" : "stack_field",
+                            "value" : ["h2", "hdr_type"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x02"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "op" : "d2b",
+                    "left" : null,
+                    "right" : {
+                      "type" : "field",
+                      "value" : ["scalars", "tmp_0"]
+                    }
+                  }
+                },
+                {
+                  "type" : "hexstr",
+                  "value" : "7"
+                }
+              ],
+              "op" : "verify"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "0x02",
+              "mask" : null,
+              "next_state" : "parse_h2"
+            },
+            {
+              "value" : "0x03",
+              "mask" : null,
+              "next_state" : "parse_h3"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "stack_field",
+              "value" : ["h2", "next_hdr_type"]
+            }
+          ]
+        },
+        {
+          "name" : "parse_h3",
+          "id" : 2,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "h3"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_1"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "b2d",
+                      "left" : null,
+                      "right" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "==",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h3", "hdr_type"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x03"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "op" : "d2b",
+                    "left" : null,
+                    "right" : {
+                      "type" : "field",
+                      "value" : ["scalars", "tmp_1"]
+                    }
+                  }
+                },
+                {
+                  "type" : "hexstr",
+                  "value" : "7"
+                }
+              ],
+              "op" : "verify"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "examples/header-stack-ops-bmv2.p4",
+        "line" : 222,
+        "column" : 8,
+        "source_fragment" : "DeparserI"
+      },
+      "order" : ["h1", "h2[0]", "h2[1]", "h2[2]", "h2[3]", "h2[4]", "h3"]
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "act",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 94,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_0",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 96,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_1",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 98,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_2",
+      "id" : 3,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 100,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_3",
+      "id" : 4,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 102,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_4",
+      "id" : 5,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 104,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_5",
+      "id" : 6,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 109,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_6",
+      "id" : 7,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 111,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_7",
+      "id" : 8,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 113,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_8",
+      "id" : 9,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 115,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_9",
+      "id" : 10,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 117,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_10",
+      "id" : 11,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 119,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_11",
+      "id" : 12,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 124,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 125,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa0"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 126,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 127,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 128,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_12",
+      "id" : 13,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 130,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 131,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 132,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 133,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 134,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_13",
+      "id" : 14,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 136,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 137,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 138,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 139,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 140,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_14",
+      "id" : 15,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 142,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 143,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 144,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 145,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 146,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_15",
+      "id" : 16,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 148,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 149,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 150,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 151,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 152,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_16",
+      "id" : 17,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 157,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_17",
+      "id" : 18,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 159,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_18",
+      "id" : 19,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 161,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_19",
+      "id" : 20,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 163,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_20",
+      "id" : 21,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 165,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_21",
+      "id" : 22,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign_header_stack",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "header_stack",
+              "value" : "h2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "act_22",
+      "id" : 23,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 94,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_23",
+      "id" : 24,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 96,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_24",
+      "id" : 25,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 98,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_25",
+      "id" : 26,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 100,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_26",
+      "id" : 27,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 102,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_27",
+      "id" : 28,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 104,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_28",
+      "id" : 29,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 109,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_29",
+      "id" : 30,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 111,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_30",
+      "id" : 31,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 113,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_31",
+      "id" : 32,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 115,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_32",
+      "id" : 33,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 117,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_33",
+      "id" : 34,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 119,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_34",
+      "id" : 35,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 124,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 125,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa0"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 126,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 127,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 128,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_35",
+      "id" : 36,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 130,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 131,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 132,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 133,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 134,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_36",
+      "id" : 37,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 136,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 137,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 138,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 139,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 140,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_37",
+      "id" : 38,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 142,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 143,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 144,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 145,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 146,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_38",
+      "id" : 39,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 148,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 149,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 150,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 151,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 152,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_39",
+      "id" : 40,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 157,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_40",
+      "id" : 41,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 159,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_41",
+      "id" : 42,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 161,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_42",
+      "id" : 43,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 163,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_43",
+      "id" : 44,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 165,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_44",
+      "id" : 45,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign_header_stack",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "h2"
+            },
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "act_45",
+      "id" : 46,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 94,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_46",
+      "id" : 47,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 96,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_47",
+      "id" : 48,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 98,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_48",
+      "id" : 49,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 100,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_49",
+      "id" : 50,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 102,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_50",
+      "id" : 51,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "push",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 104,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.push_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_51",
+      "id" : 52,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 109,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(1)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_52",
+      "id" : 53,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 111,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(2)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_53",
+      "id" : 54,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 113,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(3)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_54",
+      "id" : 55,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 115,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(4)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_55",
+      "id" : 56,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x5"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 117,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(5)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_56",
+      "id" : 57,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "pop",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x6"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 119,
+            "column" : 16,
+            "source_fragment" : "hdr.h2.pop_front(6)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_57",
+      "id" : 58,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 124,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 125,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa0"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 126,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f1 = 0xa0"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x0a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 127,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].f2 = 0x0a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[0]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 128,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_58",
+      "id" : 59,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 130,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 131,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa1"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 132,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f1 = 0xa1"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x1a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 133,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].f2 = 0x1a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[1]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 134,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_59",
+      "id" : 60,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 136,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 137,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa2"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 138,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f1 = 0xa2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x2a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 139,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].f2 = 0x2a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[2]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 140,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_60",
+      "id" : 61,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 142,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 143,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa3"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 144,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f1 = 0xa3"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x3a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 145,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].f2 = 0x3a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[3]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 146,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_61",
+      "id" : 62,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "add_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 148,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setValid()"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 149,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].hdr_type = 2"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f1"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0xa4"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 150,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f1 = 0xa4"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "f2"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x4a"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 151,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].f2 = 0x4a"
+          }
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_1_h2[4]", "next_hdr_type"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x09"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 152,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].next_hdr_type = 9"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_62",
+      "id" : 63,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[0]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 157,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[0].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_63",
+      "id" : 64,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[1]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 159,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[1].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_64",
+      "id" : 65,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[2]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 161,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[2].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_65",
+      "id" : 66,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[3]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 163,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[3].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_66",
+      "id" : 67,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "remove_header",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "hdr_1_h2[4]"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 165,
+            "column" : 16,
+            "source_fragment" : "hdr.h2[4].setInvalid()"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_67",
+      "id" : 68,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign_header_stack",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "h2"
+            },
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "act_68",
+      "id" : 69,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "|",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["h1", "h2_valid_bits"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xfe"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x01"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 186,
+            "column" : 12,
+            "source_fragment" : "hdr.h1.h2_valid_bits[0:0] = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_69",
+      "id" : 70,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign_header_stack",
+          "parameters" : [
+            {
+              "type" : "header_stack",
+              "value" : "h2"
+            },
+            {
+              "type" : "header_stack",
+              "value" : "hdr_1_h2"
+            }
+          ]
+        },
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 184,
+            "column" : 8,
+            "source_fragment" : "hdr.h1.h2_valid_bits = 0"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_70",
+      "id" : 71,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "|",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["h1", "h2_valid_bits"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xfd"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x02"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 189,
+            "column" : 12,
+            "source_fragment" : "hdr.h1.h2_valid_bits[1:1] = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_71",
+      "id" : 72,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "|",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["h1", "h2_valid_bits"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xfb"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x04"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 192,
+            "column" : 12,
+            "source_fragment" : "hdr.h1.h2_valid_bits[2:2] = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_72",
+      "id" : 73,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "|",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["h1", "h2_valid_bits"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xf7"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x08"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 195,
+            "column" : 12,
+            "source_fragment" : "hdr.h1.h2_valid_bits[3:3] = 1"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "act_73",
+      "id" : 74,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["h1", "h2_valid_bits"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "|",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["h1", "h2_valid_bits"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xef"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x10"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 198,
+            "column" : 12,
+            "source_fragment" : "hdr.h1.h2_valid_bits[4:4] = 1"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "examples/header-stack-ops-bmv2.p4",
+        "line" : 171,
+        "column" : 8,
+        "source_fragment" : "cIngress"
+      },
+      "init_table" : "tbl_act",
+      "tables" : [
+        {
+          "name" : "tbl_act",
+          "id" : 0,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [22],
+          "actions" : ["act_21"],
+          "base_default_next" : "node_3",
+          "next_tables" : {
+            "act_21" : "node_3"
+          },
+          "default_entry" : {
+            "action_id" : 22,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_0",
+          "id" : 1,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["act"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_1",
+          "id" : 2,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["act_0"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_0" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_2",
+          "id" : 3,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["act_1"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_1" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_3",
+          "id" : 4,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [3],
+          "actions" : ["act_2"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_2" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 3,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_4",
+          "id" : 5,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [4],
+          "actions" : ["act_3"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_3" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 4,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_5",
+          "id" : 6,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [5],
+          "actions" : ["act_4"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_4" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 5,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_6",
+          "id" : 7,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [6],
+          "actions" : ["act_5"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_5" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 6,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_7",
+          "id" : 8,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [7],
+          "actions" : ["act_6"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_6" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 7,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_8",
+          "id" : 9,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [8],
+          "actions" : ["act_7"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_7" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 8,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_9",
+          "id" : 10,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [9],
+          "actions" : ["act_8"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_8" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 9,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_10",
+          "id" : 11,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [10],
+          "actions" : ["act_9"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_9" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 10,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_11",
+          "id" : 12,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [11],
+          "actions" : ["act_10"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_10" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 11,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_12",
+          "id" : 13,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [12],
+          "actions" : ["act_11"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_11" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 12,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_13",
+          "id" : 14,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [13],
+          "actions" : ["act_12"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_12" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 13,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_14",
+          "id" : 15,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [14],
+          "actions" : ["act_13"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_13" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 14,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_15",
+          "id" : 16,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [15],
+          "actions" : ["act_14"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_14" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 15,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_16",
+          "id" : 17,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [16],
+          "actions" : ["act_15"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_15" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 16,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_17",
+          "id" : 18,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [17],
+          "actions" : ["act_16"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_16" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 17,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_18",
+          "id" : 19,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [18],
+          "actions" : ["act_17"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_17" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 18,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_19",
+          "id" : 20,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [19],
+          "actions" : ["act_18"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_18" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 19,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_20",
+          "id" : 21,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [20],
+          "actions" : ["act_19"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_19" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 20,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_21",
+          "id" : 22,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [21],
+          "actions" : ["act_20"],
+          "base_default_next" : "tbl_act_22",
+          "next_tables" : {
+            "act_20" : "tbl_act_22"
+          },
+          "default_entry" : {
+            "action_id" : 21,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_22",
+          "id" : 23,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [45],
+          "actions" : ["act_44"],
+          "base_default_next" : "node_53",
+          "next_tables" : {
+            "act_44" : "node_53"
+          },
+          "default_entry" : {
+            "action_id" : 45,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_23",
+          "id" : 24,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [23],
+          "actions" : ["act_22"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_22" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 23,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_24",
+          "id" : 25,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [24],
+          "actions" : ["act_23"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_23" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 24,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_25",
+          "id" : 26,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [25],
+          "actions" : ["act_24"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_24" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 25,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_26",
+          "id" : 27,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [26],
+          "actions" : ["act_25"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_25" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 26,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_27",
+          "id" : 28,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [27],
+          "actions" : ["act_26"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_26" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 27,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_28",
+          "id" : 29,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [28],
+          "actions" : ["act_27"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_27" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 28,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_29",
+          "id" : 30,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [29],
+          "actions" : ["act_28"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_28" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 29,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_30",
+          "id" : 31,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [30],
+          "actions" : ["act_29"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_29" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 30,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_31",
+          "id" : 32,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [31],
+          "actions" : ["act_30"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_30" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 31,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_32",
+          "id" : 33,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [32],
+          "actions" : ["act_31"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_31" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 32,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_33",
+          "id" : 34,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [33],
+          "actions" : ["act_32"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_32" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 33,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_34",
+          "id" : 35,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [34],
+          "actions" : ["act_33"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_33" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 34,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_35",
+          "id" : 36,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [35],
+          "actions" : ["act_34"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_34" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 35,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_36",
+          "id" : 37,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [36],
+          "actions" : ["act_35"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_35" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 36,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_37",
+          "id" : 38,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [37],
+          "actions" : ["act_36"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_36" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 37,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_38",
+          "id" : 39,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [38],
+          "actions" : ["act_37"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_37" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 38,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_39",
+          "id" : 40,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [39],
+          "actions" : ["act_38"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_38" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 39,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_40",
+          "id" : 41,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [40],
+          "actions" : ["act_39"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_39" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 40,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_41",
+          "id" : 42,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [41],
+          "actions" : ["act_40"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_40" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 41,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_42",
+          "id" : 43,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [42],
+          "actions" : ["act_41"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_41" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 42,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_43",
+          "id" : 44,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [43],
+          "actions" : ["act_42"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_42" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 43,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_44",
+          "id" : 45,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [44],
+          "actions" : ["act_43"],
+          "base_default_next" : "tbl_act_45",
+          "next_tables" : {
+            "act_43" : "tbl_act_45"
+          },
+          "default_entry" : {
+            "action_id" : 44,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_45",
+          "id" : 46,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [68],
+          "actions" : ["act_67"],
+          "base_default_next" : "node_103",
+          "next_tables" : {
+            "act_67" : "node_103"
+          },
+          "default_entry" : {
+            "action_id" : 68,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_46",
+          "id" : 47,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [46],
+          "actions" : ["act_45"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_45" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 46,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_47",
+          "id" : 48,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [47],
+          "actions" : ["act_46"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_46" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 47,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_48",
+          "id" : 49,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [48],
+          "actions" : ["act_47"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_47" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 48,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_49",
+          "id" : 50,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [49],
+          "actions" : ["act_48"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_48" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 49,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_50",
+          "id" : 51,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [50],
+          "actions" : ["act_49"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_49" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 50,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_51",
+          "id" : 52,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [51],
+          "actions" : ["act_50"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_50" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 51,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_52",
+          "id" : 53,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [52],
+          "actions" : ["act_51"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_51" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 52,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_53",
+          "id" : 54,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [53],
+          "actions" : ["act_52"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_52" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 53,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_54",
+          "id" : 55,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [54],
+          "actions" : ["act_53"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_53" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 54,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_55",
+          "id" : 56,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [55],
+          "actions" : ["act_54"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_54" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 55,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_56",
+          "id" : 57,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [56],
+          "actions" : ["act_55"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_55" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 56,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_57",
+          "id" : 58,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [57],
+          "actions" : ["act_56"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_56" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 57,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_58",
+          "id" : 59,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [58],
+          "actions" : ["act_57"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_57" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 58,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_59",
+          "id" : 60,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [59],
+          "actions" : ["act_58"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_58" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 59,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_60",
+          "id" : 61,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [60],
+          "actions" : ["act_59"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_59" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 60,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_61",
+          "id" : 62,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [61],
+          "actions" : ["act_60"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_60" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 61,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_62",
+          "id" : 63,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [62],
+          "actions" : ["act_61"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_61" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 62,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_63",
+          "id" : 64,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [63],
+          "actions" : ["act_62"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_62" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 63,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_64",
+          "id" : 65,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [64],
+          "actions" : ["act_63"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_63" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 64,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_65",
+          "id" : 66,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [65],
+          "actions" : ["act_64"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_64" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 65,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_66",
+          "id" : 67,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [66],
+          "actions" : ["act_65"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_65" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 66,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_67",
+          "id" : 68,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [67],
+          "actions" : ["act_66"],
+          "base_default_next" : "tbl_act_68",
+          "next_tables" : {
+            "act_66" : "tbl_act_68"
+          },
+          "default_entry" : {
+            "action_id" : 67,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_68",
+          "id" : 69,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [70],
+          "actions" : ["act_69"],
+          "base_default_next" : "node_153",
+          "next_tables" : {
+            "act_69" : "node_153"
+          },
+          "default_entry" : {
+            "action_id" : 70,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_69",
+          "id" : 70,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [69],
+          "actions" : ["act_68"],
+          "base_default_next" : "node_155",
+          "next_tables" : {
+            "act_68" : "node_155"
+          },
+          "default_entry" : {
+            "action_id" : 69,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_70",
+          "id" : 71,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [71],
+          "actions" : ["act_70"],
+          "base_default_next" : "node_157",
+          "next_tables" : {
+            "act_70" : "node_157"
+          },
+          "default_entry" : {
+            "action_id" : 71,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_71",
+          "id" : 72,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [72],
+          "actions" : ["act_71"],
+          "base_default_next" : "node_159",
+          "next_tables" : {
+            "act_71" : "node_159"
+          },
+          "default_entry" : {
+            "action_id" : 72,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_72",
+          "id" : 73,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [73],
+          "actions" : ["act_72"],
+          "base_default_next" : "node_161",
+          "next_tables" : {
+            "act_72" : "node_161"
+          },
+          "default_entry" : {
+            "action_id" : 73,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_act_73",
+          "id" : 74,
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [74],
+          "actions" : ["act_73"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "act_73" : null
+          },
+          "default_entry" : {
+            "action_id" : 74,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_3",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 89,
+            "column" : 12,
+            "source_fragment" : "op == 0x00"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["h1", "op1"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "false_next" : "node_4",
+          "true_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 91,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "node_5",
+          "false_next" : "node_17"
+        },
+        {
+          "name" : "node_5",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 93,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_0",
+          "false_next" : "node_7"
+        },
+        {
+          "name" : "node_7",
+          "id" : 3,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 95,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_1",
+          "false_next" : "node_9"
+        },
+        {
+          "name" : "node_9",
+          "id" : 4,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 97,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_2",
+          "false_next" : "node_11"
+        },
+        {
+          "name" : "node_11",
+          "id" : 5,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 99,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_3",
+          "false_next" : "node_13"
+        },
+        {
+          "name" : "node_13",
+          "id" : 6,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 101,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_4",
+          "false_next" : "node_15"
+        },
+        {
+          "name" : "node_15",
+          "id" : 7,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 103,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_5",
+          "false_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_17",
+          "id" : 8,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 106,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "node_18",
+          "false_next" : "node_30"
+        },
+        {
+          "name" : "node_18",
+          "id" : 9,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 108,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_6",
+          "false_next" : "node_20"
+        },
+        {
+          "name" : "node_20",
+          "id" : 10,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 110,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_7",
+          "false_next" : "node_22"
+        },
+        {
+          "name" : "node_22",
+          "id" : 11,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 112,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_8",
+          "false_next" : "node_24"
+        },
+        {
+          "name" : "node_24",
+          "id" : 12,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 114,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_9",
+          "false_next" : "node_26"
+        },
+        {
+          "name" : "node_26",
+          "id" : 13,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 116,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_10",
+          "false_next" : "node_28"
+        },
+        {
+          "name" : "node_28",
+          "id" : 14,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 118,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_11",
+          "false_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_30",
+          "id" : 15,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 121,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "node_31",
+          "false_next" : "node_41"
+        },
+        {
+          "name" : "node_31",
+          "id" : 16,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 123,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_12",
+          "false_next" : "node_33"
+        },
+        {
+          "name" : "node_33",
+          "id" : 17,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 129,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_13",
+          "false_next" : "node_35"
+        },
+        {
+          "name" : "node_35",
+          "id" : 18,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 135,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_14",
+          "false_next" : "node_37"
+        },
+        {
+          "name" : "node_37",
+          "id" : 19,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 141,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_15",
+          "false_next" : "node_39"
+        },
+        {
+          "name" : "node_39",
+          "id" : 20,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 147,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_16",
+          "false_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_41",
+          "id" : 21,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 154,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "node_42",
+          "false_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_42",
+          "id" : 22,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 156,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_17",
+          "false_next" : "node_44"
+        },
+        {
+          "name" : "node_44",
+          "id" : 23,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 158,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_18",
+          "false_next" : "node_46"
+        },
+        {
+          "name" : "node_46",
+          "id" : 24,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 160,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_19",
+          "false_next" : "node_48"
+        },
+        {
+          "name" : "node_48",
+          "id" : 25,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 162,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_20",
+          "false_next" : "node_50"
+        },
+        {
+          "name" : "node_50",
+          "id" : 26,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 164,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op1"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_21",
+          "false_next" : "tbl_act_22"
+        },
+        {
+          "name" : "node_53",
+          "id" : 27,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 89,
+            "column" : 12,
+            "source_fragment" : "op == 0x00"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["h1", "op2"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "false_next" : "node_54",
+          "true_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_54",
+          "id" : 28,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 91,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "node_55",
+          "false_next" : "node_67"
+        },
+        {
+          "name" : "node_55",
+          "id" : 29,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 93,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_23",
+          "false_next" : "node_57"
+        },
+        {
+          "name" : "node_57",
+          "id" : 30,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 95,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_24",
+          "false_next" : "node_59"
+        },
+        {
+          "name" : "node_59",
+          "id" : 31,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 97,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_25",
+          "false_next" : "node_61"
+        },
+        {
+          "name" : "node_61",
+          "id" : 32,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 99,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_26",
+          "false_next" : "node_63"
+        },
+        {
+          "name" : "node_63",
+          "id" : 33,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 101,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_27",
+          "false_next" : "node_65"
+        },
+        {
+          "name" : "node_65",
+          "id" : 34,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 103,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_28",
+          "false_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_67",
+          "id" : 35,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 106,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "node_68",
+          "false_next" : "node_80"
+        },
+        {
+          "name" : "node_68",
+          "id" : 36,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 108,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_29",
+          "false_next" : "node_70"
+        },
+        {
+          "name" : "node_70",
+          "id" : 37,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 110,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_30",
+          "false_next" : "node_72"
+        },
+        {
+          "name" : "node_72",
+          "id" : 38,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 112,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_31",
+          "false_next" : "node_74"
+        },
+        {
+          "name" : "node_74",
+          "id" : 39,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 114,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_32",
+          "false_next" : "node_76"
+        },
+        {
+          "name" : "node_76",
+          "id" : 40,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 116,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_33",
+          "false_next" : "node_78"
+        },
+        {
+          "name" : "node_78",
+          "id" : 41,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 118,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_34",
+          "false_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_80",
+          "id" : 42,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 121,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "node_81",
+          "false_next" : "node_91"
+        },
+        {
+          "name" : "node_81",
+          "id" : 43,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 123,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_35",
+          "false_next" : "node_83"
+        },
+        {
+          "name" : "node_83",
+          "id" : 44,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 129,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_36",
+          "false_next" : "node_85"
+        },
+        {
+          "name" : "node_85",
+          "id" : 45,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 135,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_37",
+          "false_next" : "node_87"
+        },
+        {
+          "name" : "node_87",
+          "id" : 46,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 141,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_38",
+          "false_next" : "node_89"
+        },
+        {
+          "name" : "node_89",
+          "id" : 47,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 147,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_39",
+          "false_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_91",
+          "id" : 48,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 154,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op2"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "node_92",
+          "false_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_92",
+          "id" : 49,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 156,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_40",
+          "false_next" : "node_94"
+        },
+        {
+          "name" : "node_94",
+          "id" : 50,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 158,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_41",
+          "false_next" : "node_96"
+        },
+        {
+          "name" : "node_96",
+          "id" : 51,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 160,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_42",
+          "false_next" : "node_98"
+        },
+        {
+          "name" : "node_98",
+          "id" : 52,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 162,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_43",
+          "false_next" : "node_100"
+        },
+        {
+          "name" : "node_100",
+          "id" : 53,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 164,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op2"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_44",
+          "false_next" : "tbl_act_45"
+        },
+        {
+          "name" : "node_103",
+          "id" : 54,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 89,
+            "column" : 12,
+            "source_fragment" : "op == 0x00"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["h1", "op3"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "false_next" : "node_104",
+          "true_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_104",
+          "id" : 55,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 91,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op3"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "node_105",
+          "false_next" : "node_117"
+        },
+        {
+          "name" : "node_105",
+          "id" : 56,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 93,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_46",
+          "false_next" : "node_107"
+        },
+        {
+          "name" : "node_107",
+          "id" : 57,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 95,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_47",
+          "false_next" : "node_109"
+        },
+        {
+          "name" : "node_109",
+          "id" : 58,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 97,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_48",
+          "false_next" : "node_111"
+        },
+        {
+          "name" : "node_111",
+          "id" : 59,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 99,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_49",
+          "false_next" : "node_113"
+        },
+        {
+          "name" : "node_113",
+          "id" : 60,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 101,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_50",
+          "false_next" : "node_115"
+        },
+        {
+          "name" : "node_115",
+          "id" : 61,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 103,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_51",
+          "false_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_117",
+          "id" : 62,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 106,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op3"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "node_118",
+          "false_next" : "node_130"
+        },
+        {
+          "name" : "node_118",
+          "id" : 63,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 108,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_52",
+          "false_next" : "node_120"
+        },
+        {
+          "name" : "node_120",
+          "id" : 64,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 110,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_53",
+          "false_next" : "node_122"
+        },
+        {
+          "name" : "node_122",
+          "id" : 65,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 112,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_54",
+          "false_next" : "node_124"
+        },
+        {
+          "name" : "node_124",
+          "id" : 66,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 114,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_55",
+          "false_next" : "node_126"
+        },
+        {
+          "name" : "node_126",
+          "id" : 67,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 116,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 5"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x05"
+              }
+            }
+          },
+          "true_next" : "tbl_act_56",
+          "false_next" : "node_128"
+        },
+        {
+          "name" : "node_128",
+          "id" : 68,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 118,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 6"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x06"
+              }
+            }
+          },
+          "true_next" : "tbl_act_57",
+          "false_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_130",
+          "id" : 69,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 121,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op3"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "node_131",
+          "false_next" : "node_141"
+        },
+        {
+          "name" : "node_131",
+          "id" : 70,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 123,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_58",
+          "false_next" : "node_133"
+        },
+        {
+          "name" : "node_133",
+          "id" : 71,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 129,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_59",
+          "false_next" : "node_135"
+        },
+        {
+          "name" : "node_135",
+          "id" : 72,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 135,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_60",
+          "false_next" : "node_137"
+        },
+        {
+          "name" : "node_137",
+          "id" : 73,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 141,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_61",
+          "false_next" : "node_139"
+        },
+        {
+          "name" : "node_139",
+          "id" : 74,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 147,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_62",
+          "false_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_141",
+          "id" : 75,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 154,
+            "column" : 19,
+            "source_fragment" : "op[7:4] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : ">>",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["h1", "op3"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x4"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "node_142",
+          "false_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_142",
+          "id" : 76,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 156,
+            "column" : 16,
+            "source_fragment" : "op[3:0] == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "tbl_act_63",
+          "false_next" : "node_144"
+        },
+        {
+          "name" : "node_144",
+          "id" : 77,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 158,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_act_64",
+          "false_next" : "node_146"
+        },
+        {
+          "name" : "node_146",
+          "id" : 78,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 160,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 2"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x02"
+              }
+            }
+          },
+          "true_next" : "tbl_act_65",
+          "false_next" : "node_148"
+        },
+        {
+          "name" : "node_148",
+          "id" : 79,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 162,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 3"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x03"
+              }
+            }
+          },
+          "true_next" : "tbl_act_66",
+          "false_next" : "node_150"
+        },
+        {
+          "name" : "node_150",
+          "id" : 80,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 164,
+            "column" : 23,
+            "source_fragment" : "op[3:0] == 4"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["h1", "op3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x0f"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x04"
+              }
+            }
+          },
+          "true_next" : "tbl_act_67",
+          "false_next" : "tbl_act_68"
+        },
+        {
+          "name" : "node_153",
+          "id" : 81,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 185,
+            "column" : 12,
+            "source_fragment" : "hdr.h2[0].isValid()"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
+                "type" : "field",
+                "value" : ["h2[0]", "$valid$"]
+              }
+            }
+          },
+          "true_next" : "tbl_act_69",
+          "false_next" : "node_155"
+        },
+        {
+          "name" : "node_155",
+          "id" : 82,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 188,
+            "column" : 12,
+            "source_fragment" : "hdr.h2[1].isValid()"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
+                "type" : "field",
+                "value" : ["h2[1]", "$valid$"]
+              }
+            }
+          },
+          "true_next" : "tbl_act_70",
+          "false_next" : "node_157"
+        },
+        {
+          "name" : "node_157",
+          "id" : 83,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 191,
+            "column" : 12,
+            "source_fragment" : "hdr.h2[2].isValid()"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
+                "type" : "field",
+                "value" : ["h2[2]", "$valid$"]
+              }
+            }
+          },
+          "true_next" : "tbl_act_71",
+          "false_next" : "node_159"
+        },
+        {
+          "name" : "node_159",
+          "id" : 84,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 194,
+            "column" : 12,
+            "source_fragment" : "hdr.h2[3].isValid()"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
+                "type" : "field",
+                "value" : ["h2[3]", "$valid$"]
+              }
+            }
+          },
+          "true_next" : "tbl_act_72",
+          "false_next" : "node_161"
+        },
+        {
+          "name" : "node_161",
+          "id" : 85,
+          "source_info" : {
+            "filename" : "examples/header-stack-ops-bmv2.p4",
+            "line" : 197,
+            "column" : 12,
+            "source_fragment" : "hdr.h2[4].isValid()"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "d2b",
+              "left" : null,
+              "right" : {
+                "type" : "field",
+                "value" : ["h2[4]", "$valid$"]
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_act_73"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "examples/header-stack-ops-bmv2.p4",
+        "line" : 203,
+        "column" : 8,
+        "source_fragment" : "cEgress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.lf_field_list",
+      ["standard_metadata", "lf_field_list"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.resubmit_flag",
+      ["standard_metadata", "resubmit_flag"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ]
+  ]
+}

--- a/examples/header-stack-ops-bmv2.p4
+++ b/examples/header-stack-ops-bmv2.p4
@@ -1,0 +1,237 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header h1_t {
+    bit<8>  hdr_type;
+    bit<8>  op1;
+    bit<8>  op2;
+    bit<8>  op3;
+    bit<8>  h2_valid_bits;
+    bit<8>  next_hdr_type;
+}
+
+header h2_t {
+    bit<8>  hdr_type;
+    bit<8>  f1;
+    bit<8>  f2;
+    bit<8>  next_hdr_type;
+}
+
+header h3_t {
+    bit<8>  hdr_type;
+    bit<8>  data;
+}
+
+#define MAX_H2_HEADERS 5
+
+struct headers {
+    h1_t h1;
+    h2_t[MAX_H2_HEADERS] h2;
+    h3_t h3;
+}
+
+struct metadata {
+}
+
+error {
+    BadHeaderType
+}
+
+parser parserI(packet_in pkt,
+               out headers hdr,
+               inout metadata meta,
+               inout standard_metadata_t stdmeta)
+{
+    state start {
+        pkt.extract(hdr.h1);
+        verify(hdr.h1.hdr_type == 1, error.BadHeaderType);
+        transition select(hdr.h1.next_hdr_type) {
+            2: parse_h2;
+            3: parse_h3;
+            default: accept;
+        }
+    }
+    state parse_h2 {
+        pkt.extract(hdr.h2.next);
+        verify(hdr.h2.last.hdr_type == 2, error.BadHeaderType);
+        transition select(hdr.h2.last.next_hdr_type) {
+            2: parse_h2;
+            3: parse_h3;
+            default: accept;
+        }
+    }
+    state parse_h3 {
+        pkt.extract(hdr.h3);
+        verify(hdr.h3.hdr_type == 3, error.BadHeaderType);
+        transition accept;
+    }
+}
+
+control cDoOneOp(inout headers hdr,
+                 in bit<8> op)
+{
+    apply {
+        if (op == 0x00) {
+            // nop
+        } else if (op[7:4] == 1) {
+            // push_front
+            if (op[3:0] == 1) {
+                hdr.h2.push_front(1);
+            } else if (op[3:0] == 2) {
+                hdr.h2.push_front(2);
+            } else if (op[3:0] == 3) {
+                hdr.h2.push_front(3);
+            } else if (op[3:0] == 4) {
+                hdr.h2.push_front(4);
+            } else if (op[3:0] == 5) {
+                hdr.h2.push_front(5);
+            } else if (op[3:0] == 6) {
+                hdr.h2.push_front(6);
+            }
+        } else if (op[7:4] == 2) {
+            // pop_front
+            if (op[3:0] == 1) {
+                hdr.h2.pop_front(1);
+            } else if (op[3:0] == 2) {
+                hdr.h2.pop_front(2);
+            } else if (op[3:0] == 3) {
+                hdr.h2.pop_front(3);
+            } else if (op[3:0] == 4) {
+                hdr.h2.pop_front(4);
+            } else if (op[3:0] == 5) {
+                hdr.h2.pop_front(5);
+            } else if (op[3:0] == 6) {
+                hdr.h2.pop_front(6);
+            }
+        } else if (op[7:4] == 3) {
+            // setValid
+            if (op[3:0] == 0) {
+                hdr.h2[0].setValid();
+                hdr.h2[0].hdr_type = 2;
+                hdr.h2[0].f1 = 0xa0;
+                hdr.h2[0].f2 = 0x0a;
+                hdr.h2[0].next_hdr_type = 9;
+            } else if (op[3:0] == 1) {
+                hdr.h2[1].setValid();
+                hdr.h2[1].hdr_type = 2;
+                hdr.h2[1].f1 = 0xa1;
+                hdr.h2[1].f2 = 0x1a;
+                hdr.h2[1].next_hdr_type = 9;
+            } else if (op[3:0] == 2) {
+                hdr.h2[2].setValid();
+                hdr.h2[2].hdr_type = 2;
+                hdr.h2[2].f1 = 0xa2;
+                hdr.h2[2].f2 = 0x2a;
+                hdr.h2[2].next_hdr_type = 9;
+            } else if (op[3:0] == 3) {
+                hdr.h2[3].setValid();
+                hdr.h2[3].hdr_type = 2;
+                hdr.h2[3].f1 = 0xa3;
+                hdr.h2[3].f2 = 0x3a;
+                hdr.h2[3].next_hdr_type = 9;
+            } else if (op[3:0] == 4) {
+                hdr.h2[4].setValid();
+                hdr.h2[4].hdr_type = 2;
+                hdr.h2[4].f1 = 0xa4;
+                hdr.h2[4].f2 = 0x4a;
+                hdr.h2[4].next_hdr_type = 9;
+            }
+        } else if (op[7:4] == 4) {
+            // setInvalid
+            if (op[3:0] == 0) {
+                hdr.h2[0].setInvalid();
+            } else if (op[3:0] == 1) {
+                hdr.h2[1].setInvalid();
+            } else if (op[3:0] == 2) {
+                hdr.h2[2].setInvalid();
+            } else if (op[3:0] == 3) {
+                hdr.h2[3].setInvalid();
+            } else if (op[3:0] == 4) {
+                hdr.h2[4].setInvalid();
+            }
+        }
+    }
+}
+
+control cIngress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t stdmeta)
+{
+    cDoOneOp() do_one_op;
+    apply {
+        do_one_op.apply(hdr, hdr.h1.op1);
+        do_one_op.apply(hdr, hdr.h1.op2);
+        do_one_op.apply(hdr, hdr.h1.op3);
+
+        // Record valid bits of all headers in hdr.h1.h2_valid_bits
+        // output header field, so we can easily write unit tests that
+        // check whether they have the expected values.
+        hdr.h1.h2_valid_bits = 0;
+        if (hdr.h2[0].isValid()) {
+            hdr.h1.h2_valid_bits[0:0] = 1;
+        }
+        if (hdr.h2[1].isValid()) {
+            hdr.h1.h2_valid_bits[1:1] = 1;
+        }
+        if (hdr.h2[2].isValid()) {
+            hdr.h1.h2_valid_bits[2:2] = 1;
+        }
+        if (hdr.h2[3].isValid()) {
+            hdr.h1.h2_valid_bits[3:3] = 1;
+        }
+        if (hdr.h2[4].isValid()) {
+            hdr.h1.h2_valid_bits[4:4] = 1;
+        }
+    }
+}
+
+control cEgress(inout headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t stdmeta)
+{
+    apply { }
+}
+
+control vc(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control uc(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control DeparserI(packet_out packet,
+                  in headers hdr)
+{
+    apply {
+        packet.emit(hdr.h1);
+        packet.emit(hdr.h2);
+        packet.emit(hdr.h3);
+    }
+}
+
+V1Switch(parserI(),
+         vc(),
+         cIngress(),
+         cEgress(),
+         uc(),
+         DeparserI()) main;

--- a/examples/header-stack-ops-bmv2.p4
+++ b/examples/header-stack-ops-bmv2.p4
@@ -92,31 +92,31 @@ control cDoOneOp(inout headers hdr,
             // push_front
             if (op[3:0] == 1) {
                 hdr.h2.push_front(1);
-            } else if (op[3:0] == 2) {
-                hdr.h2.push_front(2);
-            } else if (op[3:0] == 3) {
-                hdr.h2.push_front(3);
+//            } else if (op[3:0] == 2) {
+//                hdr.h2.push_front(2);
+//            } else if (op[3:0] == 3) {
+//                hdr.h2.push_front(3);
             } else if (op[3:0] == 4) {
                 hdr.h2.push_front(4);
             } else if (op[3:0] == 5) {
                 hdr.h2.push_front(5);
-            } else if (op[3:0] == 6) {
-                hdr.h2.push_front(6);
+//            } else if (op[3:0] == 6) {
+//                hdr.h2.push_front(6);
             }
         } else if (op[7:4] == 2) {
             // pop_front
             if (op[3:0] == 1) {
                 hdr.h2.pop_front(1);
-            } else if (op[3:0] == 2) {
-                hdr.h2.pop_front(2);
-            } else if (op[3:0] == 3) {
-                hdr.h2.pop_front(3);
+//            } else if (op[3:0] == 2) {
+//                hdr.h2.pop_front(2);
+//            } else if (op[3:0] == 3) {
+//                hdr.h2.pop_front(3);
             } else if (op[3:0] == 4) {
                 hdr.h2.pop_front(4);
             } else if (op[3:0] == 5) {
                 hdr.h2.pop_front(5);
-            } else if (op[3:0] == 6) {
-                hdr.h2.pop_front(6);
+//            } else if (op[3:0] == 6) {
+//                hdr.h2.pop_front(6);
             }
         } else if (op[7:4] == 3) {
             // setValid
@@ -126,24 +126,24 @@ control cDoOneOp(inout headers hdr,
                 hdr.h2[0].f1 = 0xa0;
                 hdr.h2[0].f2 = 0x0a;
                 hdr.h2[0].next_hdr_type = 9;
-            } else if (op[3:0] == 1) {
-                hdr.h2[1].setValid();
-                hdr.h2[1].hdr_type = 2;
-                hdr.h2[1].f1 = 0xa1;
-                hdr.h2[1].f2 = 0x1a;
-                hdr.h2[1].next_hdr_type = 9;
-            } else if (op[3:0] == 2) {
-                hdr.h2[2].setValid();
-                hdr.h2[2].hdr_type = 2;
-                hdr.h2[2].f1 = 0xa2;
-                hdr.h2[2].f2 = 0x2a;
-                hdr.h2[2].next_hdr_type = 9;
-            } else if (op[3:0] == 3) {
-                hdr.h2[3].setValid();
-                hdr.h2[3].hdr_type = 2;
-                hdr.h2[3].f1 = 0xa3;
-                hdr.h2[3].f2 = 0x3a;
-                hdr.h2[3].next_hdr_type = 9;
+//            } else if (op[3:0] == 1) {
+//                hdr.h2[1].setValid();
+//                hdr.h2[1].hdr_type = 2;
+//                hdr.h2[1].f1 = 0xa1;
+//                hdr.h2[1].f2 = 0x1a;
+//                hdr.h2[1].next_hdr_type = 9;
+//            } else if (op[3:0] == 2) {
+//                hdr.h2[2].setValid();
+//                hdr.h2[2].hdr_type = 2;
+//                hdr.h2[2].f1 = 0xa2;
+//                hdr.h2[2].f2 = 0x2a;
+//                hdr.h2[2].next_hdr_type = 9;
+//            } else if (op[3:0] == 3) {
+//                hdr.h2[3].setValid();
+//                hdr.h2[3].hdr_type = 2;
+//                hdr.h2[3].f1 = 0xa3;
+//                hdr.h2[3].f2 = 0x3a;
+//                hdr.h2[3].next_hdr_type = 9;
             } else if (op[3:0] == 4) {
                 hdr.h2[4].setValid();
                 hdr.h2[4].hdr_type = 2;
@@ -155,12 +155,12 @@ control cDoOneOp(inout headers hdr,
             // setInvalid
             if (op[3:0] == 0) {
                 hdr.h2[0].setInvalid();
-            } else if (op[3:0] == 1) {
-                hdr.h2[1].setInvalid();
-            } else if (op[3:0] == 2) {
-                hdr.h2[2].setInvalid();
-            } else if (op[3:0] == 3) {
-                hdr.h2[3].setInvalid();
+//            } else if (op[3:0] == 1) {
+//                hdr.h2[1].setInvalid();
+//            } else if (op[3:0] == 2) {
+//                hdr.h2[2].setInvalid();
+//            } else if (op[3:0] == 3) {
+//                hdr.h2[3].setInvalid();
             } else if (op[3:0] == 4) {
                 hdr.h2[4].setInvalid();
             }
@@ -173,30 +173,28 @@ control cIngress(inout headers hdr,
                  inout standard_metadata_t stdmeta)
 {
     cDoOneOp() do_one_op;
+    table debug_h2_valid_bits {
+        key = {
+            hdr.h1.h2_valid_bits : exact;
+        }
+        actions = { NoAction; }
+        const default_action = NoAction();
+    }
     apply {
         do_one_op.apply(hdr, hdr.h1.op1);
         do_one_op.apply(hdr, hdr.h1.op2);
-        do_one_op.apply(hdr, hdr.h1.op3);
+//        do_one_op.apply(hdr, hdr.h1.op3);
 
         // Record valid bits of all headers in hdr.h1.h2_valid_bits
         // output header field, so we can easily write unit tests that
         // check whether they have the expected values.
-        hdr.h1.h2_valid_bits = 0;
-        if (hdr.h2[0].isValid()) {
-            hdr.h1.h2_valid_bits[0:0] = 1;
-        }
-        if (hdr.h2[1].isValid()) {
-            hdr.h1.h2_valid_bits[1:1] = 1;
-        }
-        if (hdr.h2[2].isValid()) {
-            hdr.h1.h2_valid_bits[2:2] = 1;
-        }
-        if (hdr.h2[3].isValid()) {
-            hdr.h1.h2_valid_bits[3:3] = 1;
-        }
-        if (hdr.h2[4].isValid()) {
-            hdr.h1.h2_valid_bits[4:4] = 1;
-        }
+        hdr.h1.h2_valid_bits = (
+            (hdr.h2[0].isValid() ? (8w1 << 0) : 0) |
+            (hdr.h2[1].isValid() ? (8w1 << 1) : 0) |
+            (hdr.h2[2].isValid() ? (8w1 << 2) : 0) |
+            (hdr.h2[3].isValid() ? (8w1 << 3) : 0) |
+            (hdr.h2[4].isValid() ? (8w1 << 4) : 0));
+        debug_h2_valid_bits.apply();
     }
 }
 

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -87,7 +87,12 @@ set -x
 # There are some primitive actions in the JSON that are not yet
 # supported by p4pktgen, like clone and hash.
 #OPTS="--allow-uninitialized-reads --allow-unimplemented-primitives"
-#p4pktgen ${OPTS} examples/switch-p416-nohdrstacks.json
+#OPTS="--allow-uninitialized-reads --allow-unimplemented-primitives -mpp 1 -rss -tlubf"
+# The options on the next line are intended to run with the latest
+# version of p4pktgen as of 2018-Jan-26 on the branch named
+# hybrid_packet
+OPTS="--allow-uninitialized-reads --allow-unimplemented-primitives -mpp 1 -tlubf -epl"
+p4pktgen ${OPTS} examples/switch-p416-nohdrstacks.json
 
 #p4pktgen ${OPTS} $HOME/p4-docs/test-p4-programs/p4c-issue-950.json
 #p4pktgen ${OPTS} $HOME/p4-docs/test-p4-programs/p4c-issue-950-hand-edited1.json
@@ -99,7 +104,7 @@ set -x
 #p4pktgen ${OPTS} examples/chksum-incremental-wrong-rfc1624-eqn2-p4c-2017-11-13.json
 #p4pktgen ${OPTS} examples/chksum-incremental-wrong-rfc1624-eqn2-p4c-2017-11-14.json
 #p4pktgen ${OPTS} examples/chksum-incremental-wrong-rfc1624-eqn2-issue983-workaround-p4c-2017-11-13.json
-p4pktgen ${OPTS} examples/chksum-incremental-wrong-rfc1624-eqn2-issue983-workaround-p4c-2017-11-14.json
+#p4pktgen ${OPTS} examples/chksum-incremental-wrong-rfc1624-eqn2-issue983-workaround-p4c-2017-11-14.json
 
 #p4pktgen ${OPTS} examples/chksum2.json
 #p4pktgen ${OPTS} examples/chksum3.json


### PR DESCRIPTION
This is a program that I wrote, along with several example-based
packet tests in an STF file, in this Github PR:

    https://github.com/p4lang/p4c/pull/1129

It has at least 23^3 paths in it as written, so way more than you want
to exercise with p4pktgen.  We could pretty easily comment out or
delete a bunch of the cases to cut it down.  Also perhaps call the
sub-control 2 times instead of 3 to change exponent from 3 to 2.  Also
perhaps replace the 5 if statements that fill in the output header
bits with a single expression with shifting and bitwise ORing to avoid
the ifs, then follow that with a table search on a key containing
those 5 bits (and the rest of the 8 bits it is in, if you want).  That
would force p4pktgen to put its predicted value for those 5 bits into
a table search key in order to match.