### PR TITLE
Handle registers in BMv2 JSON, and things without source_info

### DIFF
--- a/src/p4pktgen/hlir/type_value.py
+++ b/src/p4pktgen/hlir/type_value.py
@@ -114,6 +114,14 @@ class TypeValueMeterArray(TypeValue):
         return 'MeterArray<{}>'.format(self.counter_meter_name)
 
 
+class TypeValueRegisterArray(TypeValue):
+    def __init__(self, json_obj):
+        self.register_name = json_obj
+
+    def __repr__(self):
+        return 'RegisterArray<{}>'.format(self.register_name)
+
+
 class TypeValueRegular(TypeValue):
     def __init__(self, json_obj):
         self.header_name = json_obj
@@ -163,6 +171,8 @@ def parse_type_value(json_obj):
         return TypeValueCounterArray(value)
     elif p4_type_str == 'meter_array':
         return TypeValueMeterArray(value)
+    elif p4_type_str == 'register_array':
+        return TypeValueRegisterArray(value)
     elif p4_type_str == 'regular':
         return TypeValueRegular(value)
     elif p4_type_str == 'lookahead':

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -261,10 +261,12 @@ def generate_graphviz_graph(pipeline, graph, lcas={}):
                 # if the entire condition is in the source_fragment,
                 # which requires that the condition all be placed in
                 # one line in the actual P4_16 source file.
-                if 'isValid' in si.source_fragment:
+                if (si is not None) and ('isValid' in si.source_fragment):
                     node_color = "red"
                 node_label_str = ("%s (line %d)\n%s"
-                                  "" % (node_str, si.line,
+                                  "" % (node_str,
+                                        -1 if si is None else si.line,
+                                        "" if si is None else
                                         break_into_lines(si.source_fragment)))
         else:
             node_str = node


### PR DESCRIPTION
This does not attempt to handle registers in a complete fashion --
only to be able to read BMv2 JSON files that contain them, without
raising an exception.