### PR TITLE
Travis: Use Thrift 0.12.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ addons:
 script:
   - ccache -M 1G
   - ccache -z
+  - bash tools/install-thrift.sh
   - git clone https://github.com/p4lang/behavioral-model.git
   - cd behavioral-model
-  - bash travis/install-thrift.sh
   - bash travis/install-nanomsg.sh
   - ./autogen.sh
   - ./configure 'CXXFLAGS=-Wno-sign-compare' 

--- a/tools/install-thrift.sh
+++ b/tools/install-thrift.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+git clone -b 0.12.0 https://github.com/apache/thrift.git thrift-0.12.0
+cd thrift-0.12.0
+./bootstrap.sh
+./configure \
+    --with-c_glib=no \
+    --with-cpp=yes \
+    --with-erlang=no \
+    --with-go=no \
+    --with-java=no \
+    --with-lua=no \
+    --with-nodejs=no \
+    --with-php=no \
+    --with-ruby=no
+make -j "$(nproc)"
+sudo make install
+cd lib/py
+sudo python setup.py install


### PR DESCRIPTION
The script in `behavioral-model` for installing Thrift uses an older version, which fails to build in Travis's environment.