### PR TITLE
Add support for variable-length extractions to elements of header stacks.

### DIFF
--- a/examples/header-stack-variable-length.json
+++ b/examples/header-stack-variable-length.json
@@ -1,0 +1,326 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 32, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "length_hdr",
+      "id" : 2,
+      "fields" : [
+        ["length", 8, false]
+      ]
+    },
+    {
+      "name" : "variable_length_hdr",
+      "id" : 3,
+      "fields" : [
+        ["content", "*"]
+      ],
+      "max_length" : 32
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "length",
+      "id" : 2,
+      "header_type" : "length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "stack[0]",
+      "id" : 3,
+      "header_type" : "variable_length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "stack",
+      "id" : 0,
+      "header_type" : "variable_length_hdr",
+      "size" : 1,
+      "header_ids" : [3]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6],
+    ["ParserInvalidArgument", 7]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "length"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "length"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-variable-length.p4",
+        "line" : 40,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "headerstackvariablelength45",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "header-stack-variable-length.p4",
+            "line" : 45,
+            "column" : 8,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-variable-length.p4",
+        "line" : 41,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_headerstackvariablelength45",
+      "tables" : [
+        {
+          "name" : "tbl_headerstackvariablelength45",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "header-stack-variable-length.p4",
+            "line" : 45,
+            "column" : 8,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["headerstackvariablelength45"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "headerstackvariablelength45" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "header-stack-variable-length.p4",
+        "line" : 38,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./header-stack-variable-length.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/header-stack-variable-length.p4
+++ b/examples/header-stack-variable-length.p4
@@ -1,0 +1,50 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* The idea of this test is to demonstrate that it is possible to perform a
+ * variable-length extraction into a header stack.  To this end, we create a
+ * single-element header stack and extract a portion of the packet into its
+ * only member of a length read from the packet. */
+
+header length_hdr {
+    bit<8> length;
+}
+header variable_length_hdr {
+    varbit<256> content;
+}
+struct Header_t {
+    length_hdr length;
+    variable_length_hdr[1] stack;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        /* Read the length from the packet. */
+        b.extract(h.length);
+
+        /* This is the operative part: read packet data of the length extracted
+         * above into the first element of the header stack. */
+        b.extract(h.stack.next, (bit<32>)h.length.length);
+
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        mark_to_drop(standard_meta);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/parser-cycle.json
+++ b/examples/parser-cycle.json
@@ -1,0 +1,292 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "repeating_hdr",
+      "id" : 2,
+      "fields" : [
+        ["is_terminal", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "repeating[0]",
+      "id" : 2,
+      "header_type" : "repeating_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "repeating[1]",
+      "id" : 3,
+      "header_type" : "repeating_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "repeating[2]",
+      "id" : 4,
+      "header_type" : "repeating_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "repeating",
+      "id" : 0,
+      "header_type" : "repeating_hdr",
+      "size" : 3,
+      "header_ids" : [2, 3, 4]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6],
+    ["ParserInvalidArgument", 7]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "repeating"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x00",
+              "mask" : null,
+              "next_state" : "start"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "stack_field",
+              "value" : ["repeating", "is_terminal"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser-cycle.p4",
+        "line" : 32,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "parsercycle37",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser-cycle.p4",
+            "line" : 37,
+            "column" : 8,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser-cycle.p4",
+        "line" : 33,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_parsercycle37",
+      "tables" : [
+        {
+          "name" : "tbl_parsercycle37",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "parser-cycle.p4",
+            "line" : 37,
+            "column" : 8,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["parsercycle37"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "parsercycle37" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "parser-cycle.p4",
+        "line" : 30,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./parser-cycle.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/parser-cycle.p4
+++ b/examples/parser-cycle.p4
@@ -1,0 +1,42 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test verifies that we can fill header stacks completely, and that
+ * cycles in the parser graph are handled correctly. */
+
+header repeating_hdr {
+    bit<8> is_terminal;
+}
+struct Header_t {
+    repeating_hdr[3] repeating;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.repeating.next);
+
+        transition select(h.repeating.last.is_terminal) {
+            0:       start;
+            default: accept;
+        }
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        mark_to_drop(standard_meta);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -350,7 +350,9 @@ class P4_HLIR(object):
                         for pair in k['parameters']:
                             parser_op.value.append(parse_type_value(pair))
 
-                    if parser_op.op == p4_parser_ops_enum.extract and isinstance(parser_op.value[0], TypeValueStack):
+                    if (parser_op.op == p4_parser_ops_enum.extract or
+                        parser_op.op == p4_parser_ops_enum.extract_VL) \
+                            and isinstance(parser_op.value[0], TypeValueStack):
                         p4ps.header_stack_extracts.append(parser_op.value[0].header_name)
 
                     if parser_op.op == p4_parser_ops_enum.verify:

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -325,6 +325,18 @@ class CheckSystem:
         }
         assert results == expected_results
 
+    def check_header_stack_variable_length(self):
+        # This test case checks that we can perform variable-length extractions
+        # into header stacks.
+
+        Config().load_test_defaults()
+
+        results = process_json_file('examples/header-stack-variable-length.json')
+        expected_results = {
+            ('start', 'sink', (u'tbl_headerstackvariablelength45', u'headerstackvariablelength45')):
+            TestPathResult.SUCCESS,
+        }
+        assert results == expected_results
 
     # Fill in expected results for this test case, and change name to
     # have prefix 'check_' instead of 'xfail_', after p4pktgen has

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -338,6 +338,23 @@ class CheckSystem:
         }
         assert results == expected_results
 
+    def check_parser_cycle(self):
+        # This test case checks that we do not attempt to advance beyond the
+        # last element of a header stack.
+
+        Config().load_test_defaults()
+
+        results = process_json_file('examples/parser-cycle.json')
+        expected_results = {
+            ('start', 'sink', (u'tbl_parsercycle37', u'parsercycle37')):
+            TestPathResult.SUCCESS,
+            ('start', 'start', 'sink', (u'tbl_parsercycle37', u'parsercycle37')):
+            TestPathResult.SUCCESS,
+            ('start', 'start', 'start', 'sink', (u'tbl_parsercycle37', u'parsercycle37')):
+            TestPathResult.SUCCESS,
+        }
+        assert results == expected_results
+
     # Fill in expected results for this test case, and change name to
     # have prefix 'check_' instead of 'xfail_', after p4pktgen has
     # been modified to generate correct results for it.  It generates


### PR DESCRIPTION
This PR adds support for variable-length extractions to header stacks, as illustrated here:

https://github.com/p4pktgen/p4pktgen/blob/8c93c1b2200b401dc656fe43def4b2e96b4c18a6/examples/header-stack-variable-length.p4#L28-L30

That snippet comes from one of two test P4 programs added to the suite of tests by this PR.  The functionality itself is implemented in a1c24e7, followed by some refactoring in 547e122.

`pytest` passes when run manually.  The Travis build fails currently on `master` and consequently also on this commit.  A fix for this is proposed in #103.