### PR TITLE
Add support for solving for input metadata.

### DIFF
--- a/examples/user-metadata.json
+++ b/examples/user-metadata.json
@@ -1,0 +1,386 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["Meta_t.meta_field", 24, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "eth_frag",
+      "id" : 2,
+      "fields" : [
+        ["dmac", 48, false],
+        ["soui", 24, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "e",
+      "id" : 2,
+      "header_type" : "eth_frag",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 1],
+    ["PacketTooShort", 2],
+    ["NoMatch", 3],
+    ["StackOutOfBounds", 4],
+    ["HeaderTooShort", 5],
+    ["ParserTimeout", 6],
+    ["ParserInvalidArgument", 7]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "e"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "user-metadata.p4",
+        "line" : 73,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "usermetadata82",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 82,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "usermetadata84",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 84,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "user-metadata.p4",
+        "line" : 75,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "tbl_usermetadata82",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 82,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["usermetadata82"],
+          "base_default_next" : "node_4",
+          "next_tables" : {
+            "usermetadata82" : "node_4"
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_usermetadata84",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 84,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["usermetadata84"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "usermetadata84" : null
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 81,
+            "column" : 12,
+            "source_fragment" : "h.e.soui != 0xf53"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "!=",
+              "left" : {
+                "type" : "field",
+                "value" : ["e", "soui"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x000f53"
+              }
+            }
+          },
+          "true_next" : "tbl_usermetadata82",
+          "false_next" : "node_4"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "user-metadata.p4",
+            "line" : 83,
+            "column" : 12,
+            "source_fragment" : "m.meta_field >> 8 == h.e.soui"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : ">>",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["scalars", "Meta_t.meta_field"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0x8"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0xffffff"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "field",
+                "value" : ["e", "soui"]
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_usermetadata84"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "user-metadata.p4",
+        "line" : 71,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./user-metadata.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/user-metadata.p4
+++ b/examples/user-metadata.p4
@@ -1,0 +1,89 @@
+// (c) Copyright 2020 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES
+
+#include <core.p4>
+#include <v1model.p4>
+
+header eth_frag {
+    bit<48> dmac;
+    bit<24> soui;
+}
+struct Header_t {
+    eth_frag e;
+}
+struct Meta_t {
+    bit<24> meta_field;
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.e);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    apply {
+        /* We want to check that we can solve for the value of m.meta_field.
+         * In order to make it not entirely trivial, make that value depend on
+         * part of the packet data, which itself influences the path. */
+        if (h.e.soui != 0xf53)
+            mark_to_drop(standard_meta);
+        if (m.meta_field >> 8 == h.e.soui)
+            mark_to_drop(standard_meta);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -6,10 +6,12 @@ class Config:
 
     def load_test_defaults(self,
                            no_packet_length_errs=True,
-                           run_simple_switch=True):
+                           run_simple_switch=True,
+                           solve_for_metadata=False):
         self.debug = False
         self.silent = False
         self.allow_uninitialized_reads = False
+        self.solve_for_metadata = solve_for_metadata
         self.allow_invalid_header_writes = False
         self.record_statistics = False
         self.allow_unimplemented_primitives = False
@@ -61,6 +63,7 @@ class Config:
         self.debug = args.debug
         self.silent = args.silent
         self.allow_uninitialized_reads = args.allow_uninitialized_reads
+        self.solve_for_metadata = args.solve_for_metadata
         self.allow_invalid_header_writes = args.allow_invalid_header_writes
         self.record_statistics = args.record_statistics
         self.allow_unimplemented_primitives = args.allow_unimplemented_primitives
@@ -89,6 +92,9 @@ class Config:
 
     def get_allow_uninitialized_reads(self):
         return self.allow_uninitialized_reads
+
+    def get_solve_for_metadata(self):
+        return self.solve_for_metadata
 
     def get_allow_invalid_header_writes(self):
         return self.allow_invalid_header_writes

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -1194,12 +1194,20 @@ class Translator:
         if packet_hexstr is None:
             input_packets = []
         else:
-            # TBD: Currently we always send packets into port 0.
-            # Should generalize that later.
+            input_metadata = {
+                '.'.join(var_name):
+                    model.eval(value, model_completion=True).as_long()
+                for (var_name, value) in context.input_metadata.iteritems()
+            }
             input_packets = [
-                OrderedDict([("port", 0), ("packet_len_bytes",
-                                           packet_len_bytes), ("packet_hexstr",
-                                                               packet_hexstr)])
+                OrderedDict([
+                    # TBD: Currently we always send packets into port 0.
+                    # Should generalize that later.
+                    ("port", 0),
+                    ("packet_len_bytes", packet_len_bytes),
+                    ("packet_hexstr", packet_hexstr),
+                    ("input_metadata", input_metadata),
+                ])
             ]
 
         # TBD: Would be nice to get rid of u in front of strings on

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -65,6 +65,13 @@ def main():
         """After reading BMv2 JSON file, print all parser paths, sorted by path length."""
     )
     parser.add_argument(
+        '-sm',
+        '--solve-for-metadata',
+        dest='solve_for_metadata',
+        action='store_true',
+        default=False,
+        help='Solve for initial values of standard and user metadata')
+    parser.add_argument(
         '-au',
         '--allow-uninitialized-reads',
         dest='allow_uninitialized_reads',

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -303,6 +303,29 @@ class CheckSystem:
         assert results == expected_results
 
 
+    def check_user_metadata(self):
+        # This test case checks that we can solve for values of input metadata.
+
+        # There's no plumbing from the solved metadata to simple_switch, so
+        # disable it.
+        Config().load_test_defaults(solve_for_metadata=True,
+                                    run_simple_switch=False)
+
+        results = process_json_file('examples/user-metadata.json')
+        expected_results = {
+            ('start', 'sink', (u'node_2', (False, (u'user-metadata.p4', 81, u'h.e.soui != 0xf53'))), (u'node_4', (False, (u'user-metadata.p4', 83, u'm.meta_field >> 8 == h.e.soui')))):
+            TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (False, (u'user-metadata.p4', 81, u'h.e.soui != 0xf53'))), (u'node_4', (True, (u'user-metadata.p4', 83, u'm.meta_field >> 8 == h.e.soui'))), (u'tbl_usermetadata84', u'usermetadata84')):
+            TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (True, (u'user-metadata.p4', 81, u'h.e.soui != 0xf53'))), (u'tbl_usermetadata82', u'usermetadata82'), (u'node_4', (False, (u'user-metadata.p4', 83, u'm.meta_field >> 8 == h.e.soui')))):
+            TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (True, (u'user-metadata.p4', 81, u'h.e.soui != 0xf53'))), (u'tbl_usermetadata82', u'usermetadata82'), (u'node_4', (True, (u'user-metadata.p4', 83, u'm.meta_field >> 8 == h.e.soui'))), (u'tbl_usermetadata84', u'usermetadata84')):
+            TestPathResult.SUCCESS,
+
+        }
+        assert results == expected_results
+
+
     # Fill in expected results for this test case, and change name to
     # have prefix 'check_' instead of 'xfail_', after p4pktgen has
     # been modified to generate correct results for it.  It generates


### PR DESCRIPTION
This PR adds support for solving input metadata in addition to the packet payload.
Similar concept to an experiment in another branch:
https://github.com/p4pktgen/p4pktgen/compare/input-metadata-experiment

Without this option, metadata is treated as a regular header, and is always uninitialised and so will terminate the path if uninitialised reads are not allowed.
With this option, metadata is treated specially, and added to an input_metadata field of the input_packet structure in the output test case.