### PR TITLE
for-upstream/various-refactor

### DIFF
--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -28,6 +28,7 @@ class Config:
         self.table_opt = args.table_opt
         self.incremental = args.incremental
         self.random_tlubf = args.random_tlubf
+        self.output_path = './test-case'
 
     def get_debug(self):
         return self.debug
@@ -91,3 +92,9 @@ class Config:
 
     def get_random_tlubf(self):
         return self.random_tlubf
+
+    def get_output_json_path(self):
+        return self.output_path + '.json'
+
+    def get_output_pcap_path(self):
+        return self.output_path + '.pcap'

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -4,61 +4,6 @@ class Config:
     def __init__(self):
         self.__dict__ = self.__shared_state
 
-    def load_test_defaults(self,
-                           no_packet_length_errs=True,
-                           run_simple_switch=True,
-                           solve_for_metadata=False):
-        self.debug = False
-        self.silent = False
-        self.allow_uninitialized_reads = False
-        self.solve_for_metadata = solve_for_metadata
-        self.allow_invalid_header_writes = False
-        self.record_statistics = False
-        self.allow_unimplemented_primitives = False
-        self.dump_test_case = False
-        self.show_parser_paths = False
-        self.no_packet_length_errs = no_packet_length_errs
-        self.run_simple_switch = run_simple_switch
-        self.random_tlubf = False
-
-        # Physical Ethernet ports have a minimum frame size of 64
-        # bytes, which is 14 bytes of header, 46 bytes of payload,
-        # and 4 bytes of CRC (p4pktgen and simple_switch don't
-        # deal with the CRC).
-
-        # It appears that virtual Ethernet interfaces allow
-        # frames as short as 14 bytes, and perhaps shorter.
-
-        # Scapy's Ether() method does not support packets shorter than
-        # 6 bytes, but we no longer call Ether() on packets that
-        # p4pktgen creates, so it is not a problem to generate shorter
-        # packets.
-
-        # TBD exactly what sizes of packets are supported to be sent
-        # through a Linux virtual Ethernet interface.  It might be 60
-        # bytes, because of the minimum Ethernet frame size.
-
-        # The Ethernet minimum size does not seem to apply for packets
-        # sent to simple_switch via pcap files.
-
-        # TBD: Create the necessary constraints to use the values
-        # below as their names would imply.
-        self.min_packet_len_generated = 1
-        # TBD: Use this value in SMT variable creation to limit the
-        # size of the packet BitVec variable.
-        self.max_packet_len_generated = 1536
-
-        # None means no limit on the number of packets generated per
-        # parser path, other than the number of paths in the ingress
-        # control block.
-        self.max_paths_per_parser_path = None
-        self.num_test_cases = None
-        self.try_least_used_branches_first = False
-        self.hybrid_input = True
-        self.conditional_opt = True
-        self.table_opt = True
-        self.incremental = True
-
     def load_args(self, args):
         self.debug = args.debug
         self.silent = args.silent

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -96,7 +96,7 @@ class Translator:
         else:
             self.json_file = None
 
-        self.solver = Solver()
+        self.solver = SolverFor('QF_UFBV')
         self.solver.push()
         self.hlir = hlir
         self.pipeline = pipeline

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -309,7 +309,7 @@ class Translator:
     def parser_op_to_smt(self, context, sym_packet, parser_op, fail, pos,
                          new_pos, constraints):
         op = parser_op.op
-        if op == p4_parser_ops_enum.extract:
+        if op == P4ParserOpsEnum.extract:
             # Extract expects one parameter
             assert len(parser_op.value) == 1
             assert isinstance(parser_op.value[0],
@@ -346,7 +346,7 @@ class Translator:
                 extract_offset += BitVecVal(field.size, 32)
 
             return new_pos + extract_offset
-        elif op == p4_parser_ops_enum.set:
+        elif op == P4ParserOpsEnum.set:
             assert len(parser_op.value) == 2
             assert isinstance(parser_op.value[0], TypeValueField)
             dest_field = self.hlir.get_field(parser_op.value[0])
@@ -363,7 +363,7 @@ class Translator:
                     rhs_expr = Extract(dest_size - 1, 0, rhs_expr)
             context.insert(dest_field, rhs_expr)
             return new_pos
-        elif op == p4_parser_ops_enum.extract_VL:
+        elif op == P4ParserOpsEnum.extract_VL:
             assert len(parser_op.value) == 2
             assert isinstance(parser_op.value[0],
                               TypeValueRegular) or isinstance(
@@ -453,13 +453,13 @@ class Translator:
                     self.set_valid_field(context, header_name)
 
             return new_pos + extract_offset
-        elif op == p4_parser_ops_enum.verify:
+        elif op == P4ParserOpsEnum.verify:
             expected_result = BoolVal(False) if fail != '' else BoolVal(True)
             sym_cond = self.type_value_to_smt(context, parser_op.value[0],
                                               sym_packet, pos)
             constraints.append(sym_cond == expected_result)
             return new_pos
-        elif op == p4_parser_ops_enum.primitive:
+        elif op == P4ParserOpsEnum.primitive:
             primitive = parser_op.value[0]
             # XXX: merge with action_to_smt
             if primitive.op == 'add_header':

--- a/src/p4pktgen/hlir/transition.py
+++ b/src/p4pktgen/hlir/transition.py
@@ -40,7 +40,7 @@ class ParserTransition(Edge):
     def __eq__(self, other):
         return isinstance(
             other,
-            HLIR_Parser_Transition) and (self.type_ == other.type_) and (
+            ParserTransition) and (self.type_ == other.type_) and (
                 self.next_state_name == other.next_state_name) and (
                     self.mask == other.mask) and (self.value == other.value)
 

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -188,9 +188,9 @@ def main():
     #    format='%(levelname)s: [%(filename)s:%(lineno)s] %(message)s', level=logging.INFO)
     logging.basicConfig(
         format='%(levelname)s: %(message)s', level=logging.INFO)
-    if args.debug:
+    if Config().get_debug():
         logging.getLogger().setLevel(logging.DEBUG)
-    elif args.silent:
+    elif Config().get_silent():
         logging.getLogger().setLevel(logging.ERROR)
 
     assert args.format == 'json', 'Only json input format is currently supported'
@@ -201,11 +201,11 @@ def main():
         return
 
     # Build the IR
-    generate_test_cases(args.input_file, debug=args.debug)
+    generate_test_cases(args.input_file)
 
 
 def generate_visualizations(input_file):
-    top = P4_Top(debug=False)
+    top = P4_Top()
     top.load_json_file(input_file)
     top.build_graph(ingress=True, egress=True)
     graph_lcas = {}
@@ -231,8 +231,8 @@ def print_parser_paths(parser_paths):
             print(p)
 
 
-def generate_test_cases(input_file, debug=False):
-    top = P4_Top(debug)
+def generate_test_cases(input_file):
+    top = P4_Top()
     top.load_json_file(input_file)
 
     top.build_graph()

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -213,6 +213,24 @@ def generate_visualizations(input_file):
     generate_graphviz_graph(top.eg_pipeline, top.eg_graph)
 
 
+def print_parser_paths(parser_paths):
+    parser_paths_with_len = {}
+    for p in parser_paths:
+        parser_paths_with_len.setdefault(len(p), []).append(p)
+    for plen in sorted(parser_paths_with_len.keys()):
+        logging.info("%6d parser paths with len %2d"
+                     "" % (len(parser_paths_with_len[plen]), plen))
+    for plen in sorted(parser_paths_with_len.keys()):
+        logging.info("Contents of %6d parser paths with len %2d:"
+                     "" % (len(parser_paths_with_len[plen]), plen))
+        i = 0
+        for p in parser_paths_with_len[plen]:
+            i += 1
+            logging.info("Path %d of %d with len %d:"
+                         "" % (i, len(parser_paths_with_len[plen]), plen))
+            print(p)
+
+
 def generate_test_cases(input_file, debug=False):
     top = P4_Top(debug)
     top.load_json_file(input_file)
@@ -249,21 +267,7 @@ def generate_test_cases(input_file, debug=False):
     logging.info("Found %d parser paths, longest with length %d"
                  "" % (len(parser_paths), max_path_len))
     if Config().get_show_parser_paths():
-        parser_paths_with_len = collections.defaultdict(list)
-        for p in parser_paths:
-            parser_paths_with_len[len(p)].append(p)
-        for plen in sorted(parser_paths_with_len.keys()):
-            logging.info("%6d parser paths with len %2d"
-                         "" % (len(parser_paths_with_len[plen]), plen))
-        for plen in sorted(parser_paths_with_len.keys()):
-            logging.info("Contents of %6d parser paths with len %2d:"
-                         "" % (len(parser_paths_with_len[plen]), plen))
-            i = 0
-            for p in parser_paths_with_len[plen]:
-                i += 1
-                logging.info("Path %d of %d with len %d:"
-                             "" % (i, len(parser_paths_with_len[plen]), plen))
-                print(p)
+        print_parser_paths(parser_paths)
 
     logging.info("Counted %d paths, %d nodes, %d edges"
                  " in parser + ingress control flow graph"

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -244,7 +244,10 @@ def generate_test_cases(input_file, debug=False):
     results = OrderedDict()
 
     # TBD: Make this filename specifiable via command line option
-    test_case_writer = TestCaseWriter('test-cases.json', 'test.pcap')
+    test_case_writer = TestCaseWriter(
+        Config().get_output_json_path(),
+        Config().get_output_pcap_path()
+    )
 
     num_control_paths, num_control_path_nodes, num_control_path_edges = \
         top.in_graph.count_all_paths(top.in_pipeline.init_table_name)

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -3,8 +3,6 @@ import argparse
 import logging
 from collections import defaultdict, OrderedDict
 
-from graphviz import Digraph
-
 from p4_top import P4_Top
 from config import Config
 from core.translator import Translator
@@ -12,7 +10,7 @@ from p4pktgen.core.strategy import ParserGraphVisitor, PathCoverageGraphVisitor
 from p4pktgen.core.strategy import EdgeLabels, TLUBFParserVisitor, LeastUsedPaths, EdgeCoverageGraphVisitor
 from p4pktgen.util.statistics import Statistics
 from p4pktgen.util.test_case_writer import TestCaseWriter
-from p4pktgen.hlir.transition import TransitionType, BoolTransition
+from p4pktgen.util.visualization import generate_graphviz_graph
 
 
 def main():
@@ -197,167 +195,27 @@ def main():
 
     assert args.format == 'json', 'Only json input format is currently supported'
 
+    # Generate visualizations if requested.  Do not generate test cases.
+    if args.generate_graphs:
+        generate_visualizations(args.input_file)
+        return
+
     # Build the IR
-    process_json_file(
-        args.input_file,
-        debug=args.debug,
-        generate_graphs=args.generate_graphs
-    )
+    generate_test_cases(args.input_file, debug=args.debug)
 
 
-def break_into_lines(s, max_len=40):
-    """Break s into lines, only at locations where there is whitespace in
-    s, at most `max_len` characters long.  Allow longer lines in
-    the returned string if there is no whitespace"""
-    words = s.split()
-    out_lines = []
-    cur_line = ""
-    for word in words:
-        if (len(cur_line) + 1 + len(word)) > max_len:
-            if len(cur_line) == 0:
-                out_lines.append(word)
-            else:
-                out_lines.append(cur_line)
-                cur_line = word
-        else:
-            if len(cur_line) > 0:
-                cur_line += " "
-            cur_line += word
-    if len(cur_line) > 0:
-        out_lines.append(cur_line)
-    return '\n'.join(out_lines)
+def generate_visualizations(input_file):
+    top = P4_Top(debug=False)
+    top.load_json_file(input_file)
+    top.build_graph(ingress=True, egress=True)
+    graph_lcas = {}
+    generate_graphviz_graph(top.in_pipeline, top.in_graph, lcas=graph_lcas)
+    generate_graphviz_graph(top.eg_pipeline, top.eg_graph)
 
 
-def generate_graphviz_graph(pipeline, graph, lcas={}):
-    dot = Digraph(comment=pipeline.name)
-    for node in graph.graph:
-        if node in lcas:
-            lca_str = str(lcas[node])
-            if node is None:
-                node_str = "null"
-            else:
-                node_str = str(node)
-            # By creating these edges with constraint "false",
-            # GraphViz will lay out the graph the same as if these
-            # edges did not exist, and then add these edges.  Without
-            # doing this, the node placement with these extra edges
-            # can be significantly different than without these edges,
-            # and make the control flow more difficult to see, as it
-            # isn't always top-to-bottom any longer.
-            dot.edge(
-                node_str,
-                lca_str,
-                color="orange",
-                style="dashed",
-                constraint="false")
-        if node is None:
-            continue
-        assert node in pipeline.conditionals or node in pipeline.tables
-        neighbors = graph.get_neighbors(node)
-        node_label_str = None
-        node_color = None
-        if node in pipeline.conditionals:
-            node_str = node
-            shape = 'oval'
-            if len(neighbors) > 0:
-                assert isinstance(neighbors[0], BoolTransition)
-                # True/False branch of the edge
-                assert isinstance(neighbors[0].val, bool)
-                si = neighbors[0].source_info
-                # Quick and dirty check for whether the condition uses
-                # a valid bit, but only for P4_16 programs, and only
-                # if the entire condition is in the source_fragment,
-                # which requires that the condition all be placed in
-                # one line in the actual P4_16 source file.
-                if (si is not None) and ('isValid' in si.source_fragment):
-                    node_color = "red"
-                node_label_str = ("%s (line %d)\n%s"
-                                  "" % (node_str,
-                                        -1 if si is None else si.line,
-                                        "" if si is None else
-                                        break_into_lines(si.source_fragment)))
-        else:
-            node_str = node
-            shape = 'box'
-        if node_label_str is None:
-            node_label_str = node_str
-        if node_color is None:
-            node_color = "black"
-        dot.node(node_str, node_label_str, shape=shape, color=node_color)
-        for t in neighbors:
-            transition = t
-            neighbor = t.dst
-            edge_label_str = ""
-            edge_color = "black"
-            edge_style = "solid"
-            if node in pipeline.conditionals:
-                if neighbor is None:
-                    neighbor_str = "null"
-                else:
-                    neighbor_str = str(neighbor)
-                assert isinstance(transition.val, bool)
-                edge_label_str = str(transition.val)
-                edge_style = "dashed"
-            else:
-                # Check for whether an action uses any add_header or
-                # remove_header primitive actions.  These correspond
-                # to the same named primitives in P4_14 programs, or
-                # to setValid() or setInvalid() method calls in P4_16 programs.
-                assert (transition.transition_type ==
-                        TransitionType.ACTION_TRANSITION
-                        or transition.transition_type ==
-                        TransitionType.CONST_ACTION_TRANSITION)
-
-                primitive_ops = [p.op for p in transition.action.primitives]
-                change_hdr_valid = (("add_header" in primitive_ops)
-                                    or ("remove_header" in primitive_ops))
-                if change_hdr_valid:
-                    edge_color = "green"
-                    add_header_count = 0
-                    remove_header_count = 0
-                    for op in primitive_ops:
-                        if op == "add_header":
-                            add_header_count += 1
-                        elif op == "remove_header":
-                            remove_header_count += 1
-                    edge_label_str = ""
-                    if add_header_count > 0:
-                        edge_label_str += "+%d" % (add_header_count)
-                    if remove_header_count > 0:
-                        edge_label_str += "-%d" % (remove_header_count)
-
-                if neighbor is None:
-                    neighbor_str = "null"
-                else:
-                    neighbor_str = str(neighbor)
-            assert isinstance(neighbor_str, str)
-            dot.edge(
-                node_str,
-                neighbor_str,
-                edge_label_str,
-                color=edge_color,
-                style=edge_style)
-    fname = '{}_dot.gv'.format(pipeline.name)
-    dot.render(fname, view=False)
-    logging.info("Wrote files %s and %s.pdf", fname, fname)
-
-def process_json_file(input_file, debug=False, generate_graphs=False):
+def generate_test_cases(input_file, debug=False):
     top = P4_Top(debug)
     top.load_json_file(input_file)
-
-    # Graphviz visualization
-    if generate_graphs:
-        top.build_graph(egress=True)
-        graph_lcas = {}
-        #tmp_time = time.time()
-        #for v in graph.get_nodes():
-        #    graph_lcas[v] = graph.lowest_common_ancestor(v)
-        #lca_comp_time = time.time() - tmp_time
-        #logging.info("%.3f sec to compute lowest common ancestors for ingress",
-        #             lca_comp_time)
-        generate_graphviz_graph(top.in_pipeline, top.in_graph, lcas=graph_lcas)
-        generate_graphviz_graph(top.eg_pipeline, top.eg_graph)
-        return
 
     top.build_graph()
     Statistics().init()

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -196,17 +196,14 @@ def main():
     elif args.silent:
         logging.getLogger().setLevel(logging.ERROR)
 
-    # Build the IR
-    assert args.format in ['json', 'p4']
+    assert args.format == 'json', 'Only json input format is currently supported'
 
-    if args.format == 'json':
-        process_json_file(
-            args.input_file,
-            debug=args.debug,
-            generate_graphs=args.generate_graphs)
-    else:
-        # XXX: revisit
-        top.build_from_p4(args.input_file, args.flags)
+    # Build the IR
+    process_json_file(
+        args.input_file,
+        debug=args.debug,
+        generate_graphs=args.generate_graphs
+    )
 
 
 def break_into_lines(s, max_len=40):

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -459,7 +459,7 @@ class P4_HLIR(object):
         return self.id_to_action[i]
 
     # Creates a graph that represents the parser
-    def get_parser_graph(self):
+    def build_parser_graph(self):
         graph = Graph()
 
         # Add all the transitions as edges to the graph

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -277,13 +277,12 @@ class P4_HLIR(object):
             # Create parse_states dict
             self.parse_states = OrderedDict()
 
-    def __init__(self, debug, json_obj):
+    def __init__(self, json_obj):
         """
         The order in which these objects are intialized is not arbitrary
         There is a dependence between these objects and therefore order 
         must be preserved
         """
-        self.debug = debug
         self.json_obj = json_obj
 
         # Build the IR objects as class members variables.

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -5,7 +5,7 @@ import logging
 from pprint import pprint
 from collections import defaultdict, OrderedDict
 
-from p4_utils import p4_parser_ops_enum
+from p4_utils import P4ParserOpsEnum
 from p4pktgen.hlir.type_value import *
 from p4pktgen.hlir.transition import *
 from p4pktgen.util.graph import Graph, Edge
@@ -171,18 +171,18 @@ class HLIR_Parser_Ops(object):
     def __init__(self, json_op):
         # I wish there was a neater way to do the following mapping
         if json_op['op'] == 'extract':
-            self.op = p4_parser_ops_enum.extract
+            self.op = P4ParserOpsEnum.extract
         elif json_op['op'] == 'extract_VL':
-            self.op = p4_parser_ops_enum.extract_VL
+            self.op = P4ParserOpsEnum.extract_VL
             # TODO: Needs the expression class
         elif json_op['op'] == 'set':
-            self.op = p4_parser_ops_enum.set
+            self.op = P4ParserOpsEnum.set
         elif json_op['op'] == 'verify':
-            self.op = p4_parser_ops_enum.verify
+            self.op = P4ParserOpsEnum.verify
         elif json_op['op'] == 'shift':
-            self.op = p4_parser_ops_enum.shift
+            self.op = P4ParserOpsEnum.shift
         elif json_op['op'] == 'primitive':
-            self.op = p4_parser_ops_enum.primitive
+            self.op = P4ParserOpsEnum.primitive
         else:
             raise Exception(
                 'Unexpected op: {}'.format(json_op['op']))
@@ -348,32 +348,32 @@ class P4_HLIR(object):
                 for i, k in enumerate(parse_state['parser_ops']):
                     parser_op = HLIR_Parser_Ops(k)
 
-                    if parser_op.op == p4_parser_ops_enum.primitive:
+                    if parser_op.op == P4ParserOpsEnum.primitive:
                         parser_op.value = [PrimitiveCall(k['parameters'][0])]
                     else:
                         parser_op.value = []
                         for pair in k['parameters']:
                             parser_op.value.append(parse_type_value(pair))
 
-                    if (parser_op.op == p4_parser_ops_enum.extract or
-                        parser_op.op == p4_parser_ops_enum.extract_VL) \
+                    if (parser_op.op == P4ParserOpsEnum.extract or
+                        parser_op.op == P4ParserOpsEnum.extract_VL) \
                             and isinstance(parser_op.value[0], TypeValueStack):
                         p4ps.header_stack_extracts.append(parser_op.value[0].header_name)
 
-                    if parser_op.op == p4_parser_ops_enum.verify:
+                    if parser_op.op == P4ParserOpsEnum.verify:
                         error_str = self.id_to_errors[parser_op.value[1].value]
                         p4ps.parser_ops_transitions.append([
                             ParserOpTransition(p4ps.name, parser_op, i, 'sink',
                                                error_str)
                         ])
                     elif not (Config().get_no_packet_length_errs()
-                              ) and parser_op.op == p4_parser_ops_enum.extract:
+                              ) and parser_op.op == P4ParserOpsEnum.extract:
                         p4ps.parser_ops_transitions.append([
                             ParserOpTransition(p4ps.name, parser_op, i, 'sink',
                                                'PacketTooShort')
                         ])
                     elif not (Config().get_no_packet_length_errs(
-                    )) and parser_op.op == p4_parser_ops_enum.extract_VL:
+                    )) and parser_op.op == P4ParserOpsEnum.extract_VL:
                         p4ps.parser_ops_transitions.append([
                             ParserOpTransition(p4ps.name, parser_op, i, 'sink',
                                                'PacketTooShort')

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -15,6 +15,244 @@ HIT_ID = -1
 MISS_ID = -2
 
 
+class HLIR_Meta(object):
+    """Class to represent a P4 meta field"""
+
+    def __init__(self, json_obj):
+        # Set version, it should exist
+        if json_obj.has_key('version') and json_obj['version'] != None:
+            self.version = str(json_obj['version'])
+        else:
+            raise ValueError('Missing __meta__ version value')
+
+        # Set compiler, it is optional
+        if json_obj.has_key('compiler') and json_obj['compiler'] != None:
+            self.compiler = str(json_obj['compiler'])
+        else:
+            self.compiler = None
+
+
+class HLIR_Header_Types(object):
+    """Class to represent a P4 Header Type"""
+
+    def __init__(self, json_obj):
+        # Set name, it should exist
+        if json_obj.has_key('name') and json_obj['name'] != None:
+            self.name = str(json_obj['name'])
+        else:
+            raise ValueError('Missing Header_Type name value')
+
+        # Set id, it should exist
+        if json_obj.has_key('id') and json_obj['id'] != None:
+            self.id = int(json_obj['id'])
+        else:
+            raise ValueError('Missing Header_Type id value')
+
+        # Set fields, it should exist
+        fixed_length = 0
+        self.fields = OrderedDict()
+        if json_obj.has_key('fields') and json_obj['fields'] != None:
+            for f in json_obj['fields']:
+                # sign is a header field is optional
+                assert (len(f) >= 2)
+
+                # XXX: not very clean, improve code
+                if len(f) == 3:
+                    fd = HLIR_Field(f[0], int(f[1]), f[2])
+                    fixed_length += fd.size
+                elif f[1] == '*':
+                    fd = HLIR_Field(
+                        f[0], None, False, var_length=True)
+                else:
+                    fd = HLIR_Field(f[0], int(f[1]), False)
+                    fixed_length += fd.size
+                fd.header_type = self
+                self.fields[fd.name] = fd
+        else:
+            raise ValueError('Missing fields value in header type')
+
+        # Set length_exp, it is optional
+        if json_obj.has_key(
+                'length_exp') and json_obj['length_exp'] != None:
+            self.length_exp = int(json_obj['length_exp'])
+        else:
+            self.length_exp = None
+
+        # Set max_length, it is optional
+        if json_obj.has_key(
+                'max_length') and json_obj['max_length'] != None:
+            self.max_length = int(json_obj['max_length']) * 8
+
+            for field_name, field in self.fields.iteritems():
+                if field.var_length:
+                    field.size = self.max_length - fixed_length
+        else:
+            self.max_length = None
+
+
+class HLIR_Field(object):
+    """
+    Class to represent a P4 field which is part of a P4 Header Type
+    """
+
+    def __init__(self, name, size, signed, var_length=False):
+        self.name = str(name)
+        self.size = size
+        self.signed = bool(signed)
+        self.header_type = None
+        self.header = None
+        self.var_length = var_length
+
+    def __repr__(self):
+        return 'HLIR_Field({}, {} {}, {})'.format(
+            self.name, self.size, '(max)'
+            if self.var_length else '', 'True' if self.signed else 'False')
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class HLIR_Headers(object):
+    """Class to represent a header instance"""
+
+    def __init__(self, json_obj):
+        # Set name, it should exist
+        if json_obj.has_key('name') and json_obj['name'] != None:
+            self.name = str(json_obj['name'])
+        else:
+            raise ValueError('Missing Headers name value')
+
+        # Set id, it should exist
+        if json_obj.has_key('id') and json_obj['id'] != None:
+            self.id = int(json_obj['id'])
+        else:
+            raise ValueError('Missing Headers id value')
+
+        # Set initial header_type, it should exist
+        if json_obj.has_key(
+                'header_type') and json_obj['header_type'] != None:
+            self.header_type_name = str(json_obj['header_type'])
+        else:
+            raise ValueError('Missing Headers header_type value')
+
+        # Final Header_type var
+        self.header_type = None
+
+        # Set metadata, it should exist
+        if json_obj.has_key('metadata') and json_obj['metadata'] != None:
+            self.metadata = bool(json_obj['metadata'])
+        else:
+            raise ValueError('Missing Headers metadata value')
+
+        # Set pi_omit, it should exist
+        if json_obj.has_key('pi_omit') and json_obj['pi_omit'] != None:
+            self.pi_omit = bool(json_obj['pi_omit'])
+        else:
+            self.pi_omit = False
+            logging.warning('pi_omit missing from header')
+
+        # TODO: Special or hidden fields are not declared in the json but
+        # are assumed to exist
+        self.fields = OrderedDict()
+
+        if not self.metadata:
+            # Add a valid bit for headers. Metadata has no valid bit.
+            valid_field = HLIR_Field('$valid$', 1, False)
+            valid_field.header = self
+            self.fields['$valid$'] = valid_field
+
+
+# XXX: need subclasses to properly deal with primitive
+class HLIR_Parser_Ops(object):
+    """
+    Class representing the operations in a parse state
+    """
+
+    def __init__(self, json_op):
+        # I wish there was a neater way to do the following mapping
+        if json_op['op'] == 'extract':
+            self.op = p4_parser_ops_enum.extract
+        elif json_op['op'] == 'extract_VL':
+            self.op = p4_parser_ops_enum.extract_VL
+            # TODO: Needs the expression class
+        elif json_op['op'] == 'set':
+            self.op = p4_parser_ops_enum.set
+        elif json_op['op'] == 'verify':
+            self.op = p4_parser_ops_enum.verify
+        elif json_op['op'] == 'shift':
+            self.op = p4_parser_ops_enum.shift
+        elif json_op['op'] == 'primitive':
+            self.op = p4_parser_ops_enum.primitive
+        else:
+            raise Exception(
+                'Unexpected op: {}'.format(json_op['op']))
+
+
+class HLIR_Parse_States(object):
+    """
+    Class representing the parser parse_states
+    """
+
+    # Init for parse states class
+    def __init__(self, json_obj):
+        # Set name, it should exist
+        if json_obj.has_key('name') and json_obj['name'] != None:
+            self.name = str(json_obj['name'])
+        else:
+            raise ValueError('Missing Parser_States name value')
+
+        # Set id, it should exist
+        if json_obj.has_key('id') and json_obj['id'] != None:
+            self.id = int(json_obj['id'])
+        else:
+            raise ValueError('Missing Parser_States id value')
+        self.parser_ops = []
+        self.transitions = []
+        self.transition_key = []
+
+        # List of lists of transitions from parser operators. Every
+        # element in the list corresponds to a list of transitions from
+        # the parser operator with the same index.
+        self.parser_ops_transitions = []
+
+        # The header stacks that this parser state is extracting into.
+        # This is used for constructing the parser paths.
+        self.header_stack_extracts = []
+
+    def has_header_stack_extracts(self):
+        return len(self.header_stack_extracts) > 0
+
+
+class HLIR_Parser(object):
+    """
+    Class representing the p4 parser
+    """
+
+    # Init for parser class
+    def __init__(self, json_obj):
+        # Set name, it should exist
+        if json_obj.has_key('name') and json_obj['name'] != None:
+            self.name = str(json_obj['name'])
+        else:
+            raise ValueError('Missing Parser name value')
+
+        # Set id, it should exist
+        if json_obj.has_key('id') and json_obj['id'] != None:
+            self.id = int(json_obj['id'])
+        else:
+            raise ValueError('Missing Parser id value')
+
+        # Set name, it should exist
+        if json_obj.has_key(
+                'init_state') and json_obj['init_state'] != None:
+            self.init_state = str(json_obj['init_state'])
+        else:
+            raise ValueError('Missing Parser init_state value')
+
+        # Create parse_states dict
+        self.parse_states = OrderedDict()
+
+
 class P4_HLIR(object):
     PACKET_TOO_SHORT = 'PacketTooShort'
     """
@@ -46,237 +284,6 @@ class P4_HLIR(object):
             mask=mask,
             value=value)
 
-    class HLIR_Meta(object):
-        """Class to represent a P4 meta field"""
-
-        def __init__(self, json_obj):
-            # Set version, it should exist
-            if json_obj.has_key('version') and json_obj['version'] != None:
-                self.version = str(json_obj['version'])
-            else:
-                raise ValueError('Missing __meta__ version value')
-
-            # Set compiler, it is optional
-            if json_obj.has_key('compiler') and json_obj['compiler'] != None:
-                self.compiler = str(json_obj['compiler'])
-            else:
-                self.compiler = None
-
-    class HLIR_Header_Types(object):
-        """Class to represent a P4 Header Type"""
-
-        def __init__(self, json_obj):
-            # Set name, it should exist
-            if json_obj.has_key('name') and json_obj['name'] != None:
-                self.name = str(json_obj['name'])
-            else:
-                raise ValueError('Missing Header_Type name value')
-
-            # Set id, it should exist
-            if json_obj.has_key('id') and json_obj['id'] != None:
-                self.id = int(json_obj['id'])
-            else:
-                raise ValueError('Missing Header_Type id value')
-
-            # Set fields, it should exist
-            fixed_length = 0
-            self.fields = OrderedDict()
-            if json_obj.has_key('fields') and json_obj['fields'] != None:
-                for f in json_obj['fields']:
-                    # sign is a header field is optional
-                    assert (len(f) >= 2)
-
-                    # XXX: not very clean, improve code
-                    if len(f) == 3:
-                        fd = P4_HLIR.HLIR_Field(f[0], int(f[1]), f[2])
-                        fixed_length += fd.size
-                    elif f[1] == '*':
-                        fd = P4_HLIR.HLIR_Field(
-                            f[0], None, False, var_length=True)
-                    else:
-                        fd = P4_HLIR.HLIR_Field(f[0], int(f[1]), False)
-                        fixed_length += fd.size
-                    fd.header_type = self
-                    self.fields[fd.name] = fd
-            else:
-                raise ValueError('Missing fields value in header type')
-
-            # Set length_exp, it is optional
-            if json_obj.has_key(
-                    'length_exp') and json_obj['length_exp'] != None:
-                self.length_exp = int(json_obj['length_exp'])
-            else:
-                self.length_exp = None
-
-            # Set max_length, it is optional
-            if json_obj.has_key(
-                    'max_length') and json_obj['max_length'] != None:
-                self.max_length = int(json_obj['max_length']) * 8
-
-                for field_name, field in self.fields.iteritems():
-                    if field.var_length:
-                        field.size = self.max_length - fixed_length
-            else:
-                self.max_length = None
-
-    class HLIR_Field(object):
-        """
-        Class to represent a P4 field which is part of a P4 Header Type
-        """
-
-        def __init__(self, name, size, signed, var_length=False):
-            self.name = str(name)
-            self.size = size
-            self.signed = bool(signed)
-            self.header_type = None
-            self.header = None
-            self.var_length = var_length
-
-        def __repr__(self):
-            return 'HLIR_Field({}, {} {}, {})'.format(
-                self.name, self.size, '(max)'
-                if self.var_length else '', 'True' if self.signed else 'False')
-
-        def __str__(self):
-            return self.__repr__()
-
-    class HLIR_Headers(object):
-        """Class to represent a header instance"""
-
-        def __init__(self, json_obj):
-            # Set name, it should exist
-            if json_obj.has_key('name') and json_obj['name'] != None:
-                self.name = str(json_obj['name'])
-            else:
-                raise ValueError('Missing Headers name value')
-
-            # Set id, it should exist
-            if json_obj.has_key('id') and json_obj['id'] != None:
-                self.id = int(json_obj['id'])
-            else:
-                raise ValueError('Missing Headers id value')
-
-            # Set initial header_type, it should exist
-            if json_obj.has_key(
-                    'header_type') and json_obj['header_type'] != None:
-                self.header_type_name = str(json_obj['header_type'])
-            else:
-                raise ValueError('Missing Headers header_type value')
-
-            # Final Header_type var
-            self.header_type = None
-
-            # Set metadata, it should exist
-            if json_obj.has_key('metadata') and json_obj['metadata'] != None:
-                self.metadata = bool(json_obj['metadata'])
-            else:
-                raise ValueError('Missing Headers metadata value')
-
-            # Set pi_omit, it should exist
-            if json_obj.has_key('pi_omit') and json_obj['pi_omit'] != None:
-                self.pi_omit = bool(json_obj['pi_omit'])
-            else:
-                self.pi_omit = False
-                logging.warning('pi_omit missing from header')
-
-            # TODO: Special or hidden fields are not declared in the json but
-            # are assumed to exist
-            self.fields = OrderedDict()
-
-            if not self.metadata:
-                # Add a valid bit for headers. Metadata has no valid bit.
-                valid_field = P4_HLIR.HLIR_Field('$valid$', 1, False)
-                valid_field.header = self
-                self.fields['$valid$'] = valid_field
-
-    class HLIR_Parser(object):
-        """
-        Class representing the p4 parser
-        """
-
-        class HLIR_Parse_States(object):
-            """
-            Class representing the parser parse_states
-            """
-
-            # XXX: need subclasses to properly deal with primitive
-            class HLIR_Parser_Ops(object):
-                """
-                Class representing the operations in a parse state
-                """
-
-                def __init__(self, json_op):
-                    # I wish there was a neater way to do the following mapping
-                    if json_op['op'] == 'extract':
-                        self.op = p4_parser_ops_enum.extract
-                    elif json_op['op'] == 'extract_VL':
-                        self.op = p4_parser_ops_enum.extract_VL
-                        # TODO: Needs the expression class
-                    elif json_op['op'] == 'set':
-                        self.op = p4_parser_ops_enum.set
-                    elif json_op['op'] == 'verify':
-                        self.op = p4_parser_ops_enum.verify
-                    elif json_op['op'] == 'shift':
-                        self.op = p4_parser_ops_enum.shift
-                    elif json_op['op'] == 'primitive':
-                        self.op = p4_parser_ops_enum.primitive
-                    else:
-                        raise Exception(
-                            'Unexpected op: {}'.format(json_op['op']))
-
-            # Init for parse states class
-            def __init__(self, json_obj):
-                # Set name, it should exist
-                if json_obj.has_key('name') and json_obj['name'] != None:
-                    self.name = str(json_obj['name'])
-                else:
-                    raise ValueError('Missing Parser_States name value')
-
-                # Set id, it should exist
-                if json_obj.has_key('id') and json_obj['id'] != None:
-                    self.id = int(json_obj['id'])
-                else:
-                    raise ValueError('Missing Parser_States id value')
-                self.parser_ops = []
-                self.transitions = []
-                self.transition_key = []
-
-                # List of lists of transitions from parser operators. Every
-                # element in the list corresponds to a list of transitions from
-                # the parser operator with the same index.
-                self.parser_ops_transitions = []
-
-                # The header stacks that this parser state is extracting into.
-                # This is used for constructing the parser paths.
-                self.header_stack_extracts = []
-
-            def has_header_stack_extracts(self):
-                return len(self.header_stack_extracts) > 0
-
-        # Init for parser class
-        def __init__(self, json_obj):
-            # Set name, it should exist
-            if json_obj.has_key('name') and json_obj['name'] != None:
-                self.name = str(json_obj['name'])
-            else:
-                raise ValueError('Missing Parser name value')
-
-            # Set id, it should exist
-            if json_obj.has_key('id') and json_obj['id'] != None:
-                self.id = int(json_obj['id'])
-            else:
-                raise ValueError('Missing Parser id value')
-
-            # Set name, it should exist
-            if json_obj.has_key(
-                    'init_state') and json_obj['init_state'] != None:
-                self.init_state = str(json_obj['init_state'])
-            else:
-                raise ValueError('Missing Parser init_state value')
-
-            # Create parse_states dict
-            self.parse_states = OrderedDict()
-
     def __init__(self, json_obj):
         """
         The order in which these objects are intialized is not arbitrary
@@ -295,7 +302,7 @@ class P4_HLIR(object):
         # Get the meta field
         json_meta = json_obj['__meta__']
         if json_meta is not None:
-            self.meta = P4_HLIR.HLIR_Meta(json_obj['__meta__'])
+            self.meta = HLIR_Meta(json_obj['__meta__'])
         else:
             self.meta = None
             logging.warning('__meta__ field is empty')
@@ -303,19 +310,19 @@ class P4_HLIR(object):
         # Get the header_types
         self.header_types = OrderedDict()
         for header_type in json_obj['header_types']:
-            curr_hdr_type = P4_HLIR.HLIR_Header_Types(header_type)
+            curr_hdr_type = HLIR_Header_Types(header_type)
             self.header_types[curr_hdr_type.name] = curr_hdr_type
 
         # Get the headers
         self.headers = OrderedDict()
         for header in json_obj['headers']:
-            curr_hdr = P4_HLIR.HLIR_Headers(header)
+            curr_hdr = HLIR_Headers(header)
             curr_hdr.header_type = self.header_types[curr_hdr.header_type_name]
             for k, fd in self.header_types[
                     curr_hdr.header_type_name].fields.items():
                 # make a copy for this header instance
-                new_field = P4_HLIR.HLIR_Field(fd.name, fd.size, fd.signed,
-                                               fd.var_length)
+                new_field = HLIR_Field(fd.name, fd.size, fd.signed,
+                                       fd.var_length)
                 new_field.header = curr_hdr
                 new_field.header_type = fd.header_type
                 new_field.hdr = curr_hdr
@@ -335,12 +342,11 @@ class P4_HLIR(object):
 
         self.parsers = OrderedDict()
         for p in json_obj['parsers']:
-            parser = P4_HLIR.HLIR_Parser(p)
+            parser = HLIR_Parser(p)
             for parse_state in p['parse_states']:
-                p4ps = P4_HLIR.HLIR_Parser.HLIR_Parse_States(parse_state)
+                p4ps = HLIR_Parse_States(parse_state)
                 for i, k in enumerate(parse_state['parser_ops']):
-                    parser_op = P4_HLIR.HLIR_Parser.HLIR_Parse_States.HLIR_Parser_Ops(
-                        k)
+                    parser_op = HLIR_Parser_Ops(k)
 
                     if parser_op.op == p4_parser_ops_enum.primitive:
                         parser_op.value = [PrimitiveCall(k['parameters'][0])]
@@ -482,6 +488,7 @@ class P4_HLIR(object):
 
     def get_header_type(self, type_name):
         return self.header_types[type_name]
+
 
 class PrimitiveCall:
     def __init__(self, json_obj):

--- a/src/p4pktgen/p4_top.py
+++ b/src/p4pktgen/p4_top.py
@@ -18,9 +18,8 @@ def log_graph(name, graph):
 class P4_Top():
     """Top-level for P4_16 API. Takes input P4 JSON"""
 
-    def __init__(self, debug):
+    def __init__(self):
         # Set class variables
-        self.debug = debug
         self.json_file = None
         self.json_obj = None
 
@@ -43,7 +42,7 @@ class P4_Top():
 
     def build_graph(self, ingress=True, egress=False):
         # Get the parser graph
-        self.hlir = P4_HLIR(self.debug, self.json_obj)
+        self.hlir = P4_HLIR(self.json_obj)
         self.parser_graph = self.hlir.build_parser_graph()
 
         if ingress:

--- a/src/p4pktgen/p4_top.py
+++ b/src/p4pktgen/p4_top.py
@@ -1,12 +1,10 @@
 from __future__ import print_function
 import json
-from pprint import pprint
-import subprocess
 from collections import OrderedDict
 
 
 class P4_Top():
-    """Top-level for P4_16 API. Takes input P4 device and generates JSON"""
+    """Top-level for P4_16 API. Takes input P4 JSON"""
 
     # Standard Init stuff
     def __init__(self, debug):
@@ -15,44 +13,6 @@ class P4_Top():
         self.debug = debug
         self.json_file = None
         self.json_obj = None
-
-        # # Build parser graph
-        # self.graphs = P4_Graphs(self.debug, self.hlir)
-        # self.graphs.get_parser()
-
-    # Build P4 Top object from input .p4 device file
-    ## Still needs improvement ##
-
-    def build_from_p4(self, input_file, flags):
-        """
-        # Parse input_file
-        [name, version, extension] = input_file.split(".")
-        name = name.split("/")
-        outfile_name = "examples/" + name[-1] + "." + version + ".json"
-
-        call_list = ["-o", outfile_name, input_file]
-        
-        # Parse Flags
-        if flags != None:
-            flags = flags.split(" ")
-            call_list = flags + call_list
-
-        # Add compiler call
-        call_list.insert(0, "p4c-bm2-ss")
-
-        if self.debug:
-            logging.debug("The compiler call was: " + str(call_list))
-
-        for path in self.graphs.paths:
-            generate_constraints(self.hlir, path, input_file)
-
-        # Make the command line call
-        subprocess.call(call_list)
-
-        # Output file destination
-        self.json_file = outfile_name
-        self.json_obj = self.load_json(self.json_file)
-        """
 
     # Build P4 Top object from input .json file
 

--- a/src/p4pktgen/p4_top.py
+++ b/src/p4pktgen/p4_top.py
@@ -1,27 +1,59 @@
 from __future__ import print_function
+
+import logging
 import json
 from collections import OrderedDict
+
+from p4_hlir import P4_HLIR
+
+
+def log_graph(name, graph):
+    logging.debug(graph)
+    graph_sources, graph_sinks = graph.get_sources_and_sinks()
+    logging.debug("graph %s has %d sources %s, %d sinks %s"
+                  "" % (name, len(graph_sources), graph_sources,
+                        len(graph_sinks), graph_sinks))
 
 
 class P4_Top():
     """Top-level for P4_16 API. Takes input P4 JSON"""
 
-    # Standard Init stuff
     def __init__(self, debug):
-
         # Set class variables
         self.debug = debug
         self.json_file = None
         self.json_obj = None
 
-    # Build P4 Top object from input .json file
+        self.hlir = None
+        self.parser_graph = None
 
-    def build_from_json(self, input_file):
-        # Output file destination
-        self.json_file = input_file
-        self.json_obj = self.load_json(self.json_file)
+        # Ingress graph, required for generating test cases
+        self.in_pipeline = None
+        self.in_graph = None
+        self.in_source_info_to_node_name = None
+        # Egress graph, only used for graph visualisation
+        self.eg_pipeline = None
+        self.eg_graph = None
+        self.eg_source_info_to_node_name = None
 
-    # Converts the JSON file to the OD we use as our IR
-    def load_json(self, input_file):
-        data = json.load(open(input_file), object_pairs_hook=OrderedDict)
-        return data
+    def load_json_file(self, json_file):
+        self.json_file = json_file
+        self.json_obj = json.load(open(json_file),
+                                  object_pairs_hook=OrderedDict)
+
+    def build_graph(self, ingress=True, egress=False):
+        # Get the parser graph
+        self.hlir = P4_HLIR(self.debug, self.json_obj)
+        self.parser_graph = self.hlir.build_parser_graph()
+
+        if ingress:
+            assert 'ingress' in self.hlir.pipelines
+            self.in_pipeline = self.hlir.pipelines['ingress']
+            self.in_graph, self.in_source_info_to_node_name = self.in_pipeline.generate_CFG()
+            log_graph('ingress', self.in_graph)
+
+        if egress:
+            assert 'egress' in self.hlir.pipelines
+            self.eg_pipeline = self.hlir.pipelines['egress']
+            self.eg_graph, self.eg_source_info_to_node_name = self.eg_pipeline.generate_CFG()
+            log_graph('egress', self.eg_graph)

--- a/src/p4pktgen/p4_utils.py
+++ b/src/p4pktgen/p4_utils.py
@@ -2,9 +2,10 @@ from __future__ import print_function
 from enum import Enum
 
 # Enums for the parser
-p4_parser_ops_enum = Enum('p4_parser_ops',
-                          'extract extract_VL set verify shift primitive')
-p4_expression_ops_enum = Enum(
-    'p4_expression_ops',
-    'PLUS MINUS MULTIPLY LEFT_SHIFT RIGHT_SHIFT EQUAL NOT_EQUAL GREATER_THAN GREATER_OR_EQUAL LESS_THAN LESS_OR_EQUAL LOG_AND LOG_OR LOG_NOT AND OR CARET TILDE VALID VALID_UNION'
-)
+class P4ParserOpsEnum(Enum):
+    extract = 1
+    extract_VL = 2
+    set = 3
+    verify = 4
+    shift = 5
+    primitive = 6

--- a/src/p4pktgen/util/visualization.py
+++ b/src/p4pktgen/util/visualization.py
@@ -1,0 +1,144 @@
+import logging
+
+from graphviz import Digraph
+
+from p4pktgen.hlir.transition import TransitionType, BoolTransition
+
+
+def break_into_lines(s, max_len=40):
+    """Break s into lines, only at locations where there is whitespace in
+    s, at most `max_len` characters long.  Allow longer lines in
+    the returned string if there is no whitespace"""
+    words = s.split()
+    out_lines = []
+    cur_line = ""
+    for word in words:
+        if (len(cur_line) + 1 + len(word)) > max_len:
+            if len(cur_line) == 0:
+                out_lines.append(word)
+            else:
+                out_lines.append(cur_line)
+                cur_line = word
+        else:
+            if len(cur_line) > 0:
+                cur_line += " "
+            cur_line += word
+    if len(cur_line) > 0:
+        out_lines.append(cur_line)
+    return '\n'.join(out_lines)
+
+
+def generate_graphviz_graph(pipeline, graph, lcas=None):
+    dot = Digraph(comment=pipeline.name)
+    if lcas is None:
+        lcas = {}
+    for node in graph.graph:
+        if node in lcas:
+            lca_str = str(lcas[node])
+            if node is None:
+                node_str = "null"
+            else:
+                node_str = str(node)
+            # By creating these edges with constraint "false",
+            # GraphViz will lay out the graph the same as if these
+            # edges did not exist, and then add these edges.  Without
+            # doing this, the node placement with these extra edges
+            # can be significantly different than without these edges,
+            # and make the control flow more difficult to see, as it
+            # isn't always top-to-bottom any longer.
+            dot.edge(
+                node_str,
+                lca_str,
+                color="orange",
+                style="dashed",
+                constraint="false")
+        if node is None:
+            continue
+        assert node in pipeline.conditionals or node in pipeline.tables
+        neighbors = graph.get_neighbors(node)
+        node_label_str = None
+        node_color = None
+        if node in pipeline.conditionals:
+            node_str = node
+            shape = 'oval'
+            if len(neighbors) > 0:
+                assert isinstance(neighbors[0], BoolTransition)
+                # True/False branch of the edge
+                assert isinstance(neighbors[0].val, bool)
+                si = neighbors[0].source_info
+                # Quick and dirty check for whether the condition uses
+                # a valid bit, but only for P4_16 programs, and only
+                # if the entire condition is in the source_fragment,
+                # which requires that the condition all be placed in
+                # one line in the actual P4_16 source file.
+                if (si is not None) and ('isValid' in si.source_fragment):
+                    node_color = "red"
+                node_label_str = ("%s (line %d)\n%s"
+                                  "" % (node_str,
+                                        -1 if si is None else si.line,
+                                        "" if si is None else
+                                        break_into_lines(si.source_fragment)))
+        else:
+            node_str = node
+            shape = 'box'
+        if node_label_str is None:
+            node_label_str = node_str
+        if node_color is None:
+            node_color = "black"
+        dot.node(node_str, node_label_str, shape=shape, color=node_color)
+        for t in neighbors:
+            transition = t
+            neighbor = t.dst
+            edge_label_str = ""
+            edge_color = "black"
+            edge_style = "solid"
+            if node in pipeline.conditionals:
+                if neighbor is None:
+                    neighbor_str = "null"
+                else:
+                    neighbor_str = str(neighbor)
+                assert isinstance(transition.val, bool)
+                edge_label_str = str(transition.val)
+                edge_style = "dashed"
+            else:
+                # Check for whether an action uses any add_header or
+                # remove_header primitive actions.  These correspond
+                # to the same named primitives in P4_14 programs, or
+                # to setValid() or setInvalid() method calls in P4_16 programs.
+                assert (transition.transition_type ==
+                        TransitionType.ACTION_TRANSITION
+                        or transition.transition_type ==
+                        TransitionType.CONST_ACTION_TRANSITION)
+
+                primitive_ops = [p.op for p in transition.action.primitives]
+                change_hdr_valid = (("add_header" in primitive_ops)
+                                    or ("remove_header" in primitive_ops))
+                if change_hdr_valid:
+                    edge_color = "green"
+                    add_header_count = 0
+                    remove_header_count = 0
+                    for op in primitive_ops:
+                        if op == "add_header":
+                            add_header_count += 1
+                        elif op == "remove_header":
+                            remove_header_count += 1
+                    edge_label_str = ""
+                    if add_header_count > 0:
+                        edge_label_str += "+%d" % (add_header_count)
+                    if remove_header_count > 0:
+                        edge_label_str += "-%d" % (remove_header_count)
+
+                if neighbor is None:
+                    neighbor_str = "null"
+                else:
+                    neighbor_str = str(neighbor)
+            assert isinstance(neighbor_str, str)
+            dot.edge(
+                node_str,
+                neighbor_str,
+                edge_label_str,
+                color=edge_color,
+                style=edge_style)
+    fname = '{}_dot.gv'.format(pipeline.name)
+    dot.render(fname, view=False)
+    logging.info("Wrote files %s and %s.pdf", fname, fname)

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -57,6 +57,7 @@ def load_test_config(no_packet_length_errs=True,
     config.conditional_opt = True
     config.table_opt = True
     config.incremental = True
+    config.output_path = './test-case'
 
 
 class CheckSystem:

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -1,4 +1,4 @@
-from p4pktgen.main import process_json_file
+from p4pktgen.main import generate_test_cases
 from p4pktgen.config import Config
 from p4pktgen.core.translator import TestPathResult
 
@@ -6,7 +6,7 @@ from p4pktgen.core.translator import TestPathResult
 class CheckSystem:
     def check_demo1b(self):
         Config().load_test_defaults()
-        results = process_json_file('examples/demo1b.json')
+        results = generate_test_cases('examples/demo1b.json')
         expected_results = {
             ('start', 'sink', (u'node_2', (True, (u'demo1b.p4', 141, u'hdr.ipv4.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
@@ -35,7 +35,7 @@ class CheckSystem:
 
     def check_demo1(self):
         Config().load_test_defaults()
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/demo1-action-names-uniquified.p4_16.json')
         expected_results = {
             ('start', 'sink', (u'ingress.ipv4_da_lpm', u'ingress.set_l2ptr')):
@@ -55,7 +55,7 @@ class CheckSystem:
 
     def check_demo1_no_uninit_reads(self):
         Config().load_test_defaults()
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/demo1-no-uninit-reads.p4_16.json')
         expected_results = {
             ('start', 'parse_ipv4', 'sink', (u'tbl_demo1nouninitreads120', u'demo1nouninitreads120'), (u'node_3', (True, (u'demo1-no-uninit-reads.p4_16.p4', 121, u'hdr.ipv4.isValid()'))), (u'ingress.ipv4_da_lpm', u'ingress.my_drop'), (u'node_5', (True, (u'demo1-no-uninit-reads.p4_16.p4', 123, u'!meta.fwd_metadata.dropped')))):
@@ -79,7 +79,7 @@ class CheckSystem:
 
     def check_demo9b(self):
         Config().load_test_defaults()
-        results = process_json_file('examples/demo9b.json')
+        results = generate_test_cases('examples/demo9b.json')
         expected_results = {
             ('start', 'parse_ethernet', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
             TestPathResult.UNINITIALIZED_READ,
@@ -120,7 +120,7 @@ class CheckSystem:
 
     def check_config_table(self):
         Config().load_test_defaults()
-        results = process_json_file('examples/config-table.json')
+        results = generate_test_cases('examples/config-table.json')
         expected_results = {
             ('start', 'sink', (u'ingress.switch_config_params', u'ingress.set_config_parameters'), (u'ingress.mac_da', u'ingress.set_bd_dmac_intf')):
             TestPathResult.UNINITIALIZED_READ,
@@ -143,7 +143,7 @@ class CheckSystem:
 
     def check_demo1_rm_header(self):
         Config().load_test_defaults()
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/demo1_rm_header.json')
         expected_results = {
             ('start', 'parse_ipv4', 'sink', (u'tbl_demo1_rm_header83', u'demo1_rm_header83')):
@@ -155,7 +155,7 @@ class CheckSystem:
 
     def check_add_remove_header(self):
         Config().load_test_defaults()
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/add-remove-header.json')
         expected_results = {
             ('start', 'parse_ipv4', 'sink', (u'node_2', (True, (u'add-remove-header.p4', 136, u'hdr.ipv4.isValid()'))), (u'ingress.ipv4_da_lpm', u'ingress.set_l2ptr'), (u'node_4', (True, (u'add-remove-header.p4', 138, u'!hdr.outer_ipv4.isValid()'))), (u'ingress.mac_da', u'ingress.set_bd_dmac_intf')):
@@ -187,7 +187,7 @@ class CheckSystem:
         Config().load_test_defaults()
         # This test case exercises variable-length extract, lookahead,
         # and verify statements in the parser.
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/checksum-ipv4-with-options.json')
         expected_results = {
             ('start', u'parse_ipv4', u'parse_tcp', 'sink', (u'node_2', (True, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()'))), (u'node_3', (True, (u'checksum-ipv4-with-options.p4', 130, u'hdr.ipv4.ihl == 14')))):
@@ -215,7 +215,7 @@ class CheckSystem:
         # when taken, make certain paths through ingress impossible.
         # Note that there are no test cases containing the state
         # parse_unreachable_state in the parser paths.
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/parser-impossible-transitions.json')
         expected_results = {
             ('start', 'parse_good', 'sink', (u'node_2', (False, (u'parser-impossible-transitions.p4', 92, u'meta.fwd_metadata.parse_status == 0')))):
@@ -256,7 +256,7 @@ class CheckSystem:
         # Similar to the previous test case, this test case has
         # several parser paths that are impossible to traverse, and
         # several that are possible.
-        results = process_json_file(
+        results = generate_test_cases(
             'examples/parser-impossible-transitions2.json')
         expected_results = {
             ('start', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
@@ -311,7 +311,7 @@ class CheckSystem:
         Config().load_test_defaults(solve_for_metadata=True,
                                     run_simple_switch=False)
 
-        results = process_json_file('examples/user-metadata.json')
+        results = generate_test_cases('examples/user-metadata.json')
         expected_results = {
             ('start', 'sink', (u'node_2', (False, (u'user-metadata.p4', 81, u'h.e.soui != 0xf53'))), (u'node_4', (False, (u'user-metadata.p4', 83, u'm.meta_field >> 8 == h.e.soui')))):
             TestPathResult.SUCCESS,
@@ -331,7 +331,7 @@ class CheckSystem:
 
         Config().load_test_defaults()
 
-        results = process_json_file('examples/header-stack-variable-length.json')
+        results = generate_test_cases('examples/header-stack-variable-length.json')
         expected_results = {
             ('start', 'sink', (u'tbl_headerstackvariablelength45', u'headerstackvariablelength45')):
             TestPathResult.SUCCESS,
@@ -344,7 +344,7 @@ class CheckSystem:
 
         Config().load_test_defaults()
 
-        results = process_json_file('examples/parser-cycle.json')
+        results = generate_test_cases('examples/parser-cycle.json')
         expected_results = {
             ('start', 'sink', (u'tbl_parsercycle37', u'parsercycle37')):
             TestPathResult.SUCCESS,
@@ -363,7 +363,7 @@ class CheckSystem:
     # state A to parser state B.
     def xfail_parser_parallel_paths(self):
         Config().load_test_defaults()
-        results = process_json_file('examples/parser-parallel-paths.json')
+        results = generate_test_cases('examples/parser-parallel-paths.json')
         expected_results = {
         }
         assert results == expected_results


### PR DESCRIPTION
This PR encapsulates various refactoring that went on before one of our other main feature additions.
There's not much here in terms of new features, it's all about streamlining modules (mostly main.py) to make them easier to add things to in the next PRs.

The only functional changes should be the renaming of the pcap file to match the json filename and the restriction of the solver to QF_UFBV, which we haven't observed to have any detrimental effects in practice (just a performance increase).