### PR TITLE
for-upstream/stack-over-extraction

### DIFF
--- a/examples/header-stack-too-many-extracts.json
+++ b/examples/header-stack-too-many-extracts.json
@@ -1,0 +1,550 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 32, false],
+        ["tmp_0", 32, false],
+        ["tmp_1", 32, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "length_hdr",
+      "id" : 2,
+      "fields" : [
+        ["length", 8, false]
+      ]
+    },
+    {
+      "name" : "const_length_hdr",
+      "id" : 3,
+      "fields" : [
+        ["content", 32, false]
+      ]
+    },
+    {
+      "name" : "variable_length_hdr",
+      "id" : 4,
+      "fields" : [
+        ["content", "*"]
+      ],
+      "max_length" : 32
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "length",
+      "id" : 2,
+      "header_type" : "length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "stack_const[0]",
+      "id" : 3,
+      "header_type" : "const_length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "stack_vl[0]",
+      "id" : 4,
+      "header_type" : "variable_length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "stack_const",
+      "id" : 0,
+      "header_type" : "const_length_hdr",
+      "size" : 1,
+      "header_ids" : [3]
+    },
+    {
+      "name" : "stack_vl",
+      "id" : 1,
+      "header_type" : "variable_length_hdr",
+      "size" : 1,
+      "header_ids" : [4]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "length"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x01",
+              "mask" : null,
+              "next_state" : "extract_const"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02",
+              "mask" : null,
+              "next_state" : "extract_const_twice"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x10",
+              "mask" : null,
+              "next_state" : "extract_vl"
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x20",
+              "mask" : null,
+              "next_state" : "extract_vl_twice"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["length", "length"]
+            }
+          ]
+        },
+        {
+          "name" : "extract_const",
+          "id" : 1,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_const"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "extract_const_twice",
+          "id" : 2,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_const"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_const"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "extract_vl",
+          "id" : 3,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "length"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_vl"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "extract_vl_twice",
+          "id" : 4,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_0"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "length"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_vl"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp_0"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_1"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "length"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_vl"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp_1"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-too-many-extracts.p4",
+        "line" : 75,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "headerstacktoomanyextracts80",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["length", "length"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "header-stack-too-many-extracts.p4",
+            "line" : 80,
+            "column" : 8,
+            "source_fragment" : "h.length.length = 0"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-too-many-extracts.p4",
+        "line" : 76,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_headerstacktoomanyextracts80",
+      "tables" : [
+        {
+          "name" : "tbl_headerstacktoomanyextracts80",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "header-stack-too-many-extracts.p4",
+            "line" : 80,
+            "column" : 24,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["headerstacktoomanyextracts80"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "headerstacktoomanyextracts80" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "header-stack-too-many-extracts.p4",
+        "line" : 73,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./header-stack-too-many-extracts.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}
+

--- a/examples/header-stack-too-many-extracts.p4
+++ b/examples/header-stack-too-many-extracts.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test attempts to extract fields to a stacks, but will extract
+   more entries than the stacks have space for.  It exercises both
+   variable-length and non-VL extraction to stack codepaths. */
+
+header length_hdr {
+    bit<8> length;
+}
+header const_length_hdr {
+    bit<32> content;
+}
+header variable_length_hdr {
+    varbit<256> content;
+}
+struct Header_t {
+    length_hdr length;
+    const_length_hdr[1] stack_const;
+    variable_length_hdr[1] stack_vl;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.length);
+        transition select(h.length.length) {
+            0x01: extract_const;
+            0x02: extract_const_twice;
+            0x10: extract_vl;
+            0x20: extract_vl_twice;
+            default: accept;
+        }
+    }
+
+    state extract_const {
+        /* Read packet data into the first element of the header stack. */
+        b.extract(h.stack_const.next);
+
+        transition accept;
+    }
+
+    state extract_const_twice {
+        /* Read packet data into the two elements of the header stack.
+           Since the stack is only of length 1 this is invalid.*/
+        b.extract(h.stack_const.next);
+        b.extract(h.stack_const.next);
+
+        transition accept;
+    }
+
+    state extract_vl {
+        /* Read packet data into the first element of the header stack. */
+        b.extract(h.stack_vl.next, (bit<32>)h.length.length);
+
+        transition accept;
+    }
+
+    state extract_vl_twice {
+        /* Read packet data into the two elements of the header stack.
+           Since the stack is only of length 1 this is invalid.*/
+        b.extract(h.stack_vl.next, (bit<32>)h.length.length);
+        b.extract(h.stack_vl.next, (bit<32>)h.length.length);
+
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        h.length.length = 0;
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -38,16 +38,16 @@ class ParserGraphVisitor(GraphVisitor):
                         self.count(stack_counts, path[0].src)
                         for e in path:
                             self.count(stack_counts, e.dst)
-                        self.count(stack_counts, edge.dst)
+                    self.count(stack_counts, edge.dst)
 
-                        # If one of the header stacks is overful, remove the edge
-                        valid = True
-                        for stack, count in stack_counts.items():
-                            if self.hlir.get_header_stack(stack).size < count:
-                                valid = False
-                                break
-                        if not valid:
-                            continue
+                    # If one of the header stacks is overful, remove the edge
+                    valid = True
+                    for stack, count in stack_counts.items():
+                        if self.hlir.get_header_stack(stack).size < count:
+                            valid = False
+                            break
+                    if not valid:
+                        continue
 
             filtered_edges.append(edge)
 

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -429,3 +429,18 @@ class CheckSystem:
         expected_results = {
         }
         assert results == expected_results
+
+    def check_header_stack_too_many_extracts(self):
+        # This test case checks that parser paths that would result in
+        # overfilling of header stacks are not followed.
+        load_test_config()
+        results = run_test('examples/header-stack-too-many-extracts.json')
+        expected_results = {
+            ('start', 'sink', (u'tbl_headerstacktoomanyextracts80', u'headerstacktoomanyextracts80')):
+            TestPathResult.SUCCESS,
+            ('start', 'extract_const', 'sink', (u'tbl_headerstacktoomanyextracts80', u'headerstacktoomanyextracts80')):
+            TestPathResult.SUCCESS,
+            ('start', 'extract_vl', 'sink', (u'tbl_headerstacktoomanyextracts80', u'headerstacktoomanyextracts80')):
+            TestPathResult.SUCCESS,
+        }
+        assert results == expected_results


### PR DESCRIPTION
Currently it is possible to generate test cases that would extract more fields into a header stack than there is space for.
This PR fixes the check that should have prevented this and adds a test.