### PR TITLE
for-upstream/packet-fields

### DIFF
--- a/examples/lookahead-beyond-extract.json
+++ b/examples/lookahead-beyond-extract.json
@@ -1,0 +1,493 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp_0", 16, false],
+        ["tmp_1", 8, false],
+        ["userMetadata.dummy", 8, false]
+      ]
+    },
+    {
+      "name" : "long_hdr",
+      "id" : 1,
+      "fields" : [
+        ["common", 8, false],
+        ["len", 8, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "short_hdr",
+      "id" : 3,
+      "fields" : [
+        ["common", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "tmp",
+      "id" : 0,
+      "header_type" : "long_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "scalars",
+      "id" : 1,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "shorthdr",
+      "id" : 3,
+      "header_type" : "short_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "longhdr",
+      "id" : 4,
+      "header_type" : "long_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_0"]
+                },
+                {
+                  "type" : "lookahead",
+                  "value" : [0, 16]
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "parameters" : [
+                    {
+                      "type" : "header",
+                      "value" : "tmp"
+                    }
+                  ],
+                  "op" : "add_header"
+                }
+              ],
+              "op" : "primitive"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["tmp", "common"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "&",
+                          "left" : {
+                            "type" : "expression",
+                            "value" : {
+                              "op" : "&",
+                              "left" : {
+                                "type" : "expression",
+                                "value" : {
+                                  "op" : ">>",
+                                  "left" : {
+                                    "type" : "field",
+                                    "value" : ["scalars", "tmp_0"]
+                                  },
+                                  "right" : {
+                                    "type" : "hexstr",
+                                    "value" : "0x8"
+                                  }
+                                }
+                              },
+                              "right" : {
+                                "type" : "hexstr",
+                                "value" : "0xffff"
+                              }
+                            }
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0xff"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["tmp", "len"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "&",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["scalars", "tmp_0"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0xff"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp_1"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "&",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["scalars", "tmp_0"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0xff"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x00",
+              "mask" : null,
+              "next_state" : "test_short"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : "test_long"
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp_1"]
+            }
+          ]
+        },
+        {
+          "name" : "test_short",
+          "id" : 1,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "shorthdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "test_long",
+          "id" : 2,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "longhdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "lookahead-beyond-extract.p4",
+        "line" : 48,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "lookaheadbeyondextract53",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["scalars", "userMetadata.dummy"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "lookahead-beyond-extract.p4",
+            "line" : 53,
+            "column" : 8,
+            "source_fragment" : "m.dummy = 0"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "lookahead-beyond-extract.p4",
+        "line" : 49,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_lookaheadbeyondextract53",
+      "tables" : [
+        {
+          "name" : "tbl_lookaheadbeyondextract53",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "lookahead-beyond-extract.p4",
+            "line" : 53,
+            "column" : 16,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["lookaheadbeyondextract53"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "lookaheadbeyondextract53" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "lookahead-beyond-extract.p4",
+        "line" : 46,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./lookahead-beyond-extract.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}
+

--- a/examples/lookahead-beyond-extract.p4
+++ b/examples/lookahead-beyond-extract.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This example aims to test whether p4pktgen handles the case where a
+ * lookahead goes beyond the final extraction. */
+
+header short_hdr {
+    bit<8> common;
+}
+header long_hdr {
+    bit<8> common;
+    bit<8> len;
+}
+struct Header_t {
+    short_hdr shorthdr;
+    long_hdr longhdr;
+}
+struct Meta_t {
+    bit<8> dummy;
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        /* Use a lookahead to control the transition.  Only one of the two next
+         * states will extract the full header. */
+        transition select(b.lookahead<long_hdr>().len) {
+            0x00: test_short;
+            default: test_long;
+        }
+    }
+
+    state test_short {
+        b.extract(h.shorthdr);
+        transition accept;
+    }
+
+    state test_long {
+        b.extract(h.longhdr);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        m.dummy = 0;
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/narrow-extractions.json
+++ b/examples/narrow-extractions.json
@@ -1,0 +1,508 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "narrow_hdr",
+      "id" : 2,
+      "fields" : [
+        ["n0", 1, false],
+        ["n1", 1, false],
+        ["n2", 1, false],
+        ["n3", 1, false],
+        ["n4", 5, false],
+        ["n5", 3, false],
+        ["n6", 3, false],
+        ["n7", 1, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "narrow",
+      "id" : 2,
+      "header_type" : "narrow_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "narrow"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "narrow-extractions.p4",
+        "line" : 37,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "narrowextractions44",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 44,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "narrowextractions47",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 47,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "narrowextractions50",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "narrow-extractions.p4",
+        "line" : 38,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "tbl_narrowextractions44",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 44,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["narrowextractions44"],
+          "base_default_next" : "node_4",
+          "next_tables" : {
+            "narrowextractions44" : "node_4"
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_narrowextractions47",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 47,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["narrowextractions47"],
+          "base_default_next" : "node_6",
+          "next_tables" : {
+            "narrowextractions47" : "node_6"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_narrowextractions50",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["narrowextractions50"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "narrowextractions50" : null
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 42,
+            "column" : 12,
+            "source_fragment" : "h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ..."
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "and",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "and",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "and",
+                      "left" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "==",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["narrow", "n0"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x01"
+                          }
+                        }
+                      },
+                      "right" : {
+                        "type" : "expression",
+                        "value" : {
+                          "op" : "==",
+                          "left" : {
+                            "type" : "field",
+                            "value" : ["narrow", "n1"]
+                          },
+                          "right" : {
+                            "type" : "hexstr",
+                            "value" : "0x01"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "==",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["narrow", "n2"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0x01"
+                      }
+                    }
+                  }
+                }
+              },
+              "right" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "==",
+                  "left" : {
+                    "type" : "field",
+                    "value" : ["narrow", "n3"]
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x01"
+                  }
+                }
+              }
+            }
+          },
+          "true_next" : "tbl_narrowextractions44",
+          "false_next" : "node_4"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 46,
+            "column" : 12,
+            "source_fragment" : "h.narrow.n4 == 31"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["narrow", "n4"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x1f"
+              }
+            }
+          },
+          "true_next" : "tbl_narrowextractions47",
+          "false_next" : "node_6"
+        },
+        {
+          "name" : "node_6",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "narrow-extractions.p4",
+            "line" : 49,
+            "column" : 12,
+            "source_fragment" : "h.narrow.n6 == 7"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["narrow", "n6"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x07"
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_narrowextractions50"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "narrow-extractions.p4",
+        "line" : 35,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./narrow-extractions.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}
+

--- a/examples/narrow-extractions.p4
+++ b/examples/narrow-extractions.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test is intended to exercise the logic for carrying bits across
+ * extractions that are not nybble-aligned when generating hex strings for
+ * packet data. */
+
+header narrow_hdr {
+    bit<1> n0;
+    bit<1> n1;
+    bit<1> n2;
+    bit<1> n3;
+    bit<5> n4;
+    bit<3> n5;
+    bit<3> n6;
+    bit<1> n7;
+}
+struct Header_t {
+    narrow_hdr narrow;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.narrow);
+
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    apply {
+        /* Test carry of each possible width. */
+        if (h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 &&
+            h.narrow.n3 == 1)
+            mark_to_drop(standard_meta);
+        /* Test carry of one bit from a field with all bits set. */
+        if (h.narrow.n4 == 31)
+            mark_to_drop(standard_meta);
+        /* Test carry of three bits from a field with all bits set. */
+        if (h.narrow.n6 == 7)
+            mark_to_drop(standard_meta);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/switch-after-varbit.json
+++ b/examples/switch-after-varbit.json
@@ -1,0 +1,376 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 32, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "byte_hdr",
+      "id" : 2,
+      "fields" : [
+        ["value", 8, false]
+      ]
+    },
+    {
+      "name" : "variable_length_hdr",
+      "id" : 3,
+      "fields" : [
+        ["content", "*"]
+      ],
+      "max_length" : 32
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "length",
+      "id" : 2,
+      "header_type" : "byte_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "field",
+      "id" : 3,
+      "header_type" : "variable_length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "test_value",
+      "id" : 4,
+      "header_type" : "byte_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "length"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "value"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "field"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "test_value"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x00",
+              "mask" : null,
+              "next_state" : "test_zero"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : "test_non_zero"
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["test_value", "value"]
+            }
+          ]
+        },
+        {
+          "name" : "test_zero",
+          "id" : 1,
+          "parser_ops" : [],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "test_non_zero",
+          "id" : 2,
+          "parser_ops" : [],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "switch-after-varbit.p4",
+        "line" : 50,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "switchaftervarbit55",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["length", "value"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "switch-after-varbit.p4",
+            "line" : 55,
+            "column" : 8,
+            "source_fragment" : "h.length.value = 0"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "switch-after-varbit.p4",
+        "line" : 51,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_switchaftervarbit55",
+      "tables" : [
+        {
+          "name" : "tbl_switchaftervarbit55",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "switch-after-varbit.p4",
+            "line" : 55,
+            "column" : 23,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["switchaftervarbit55"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "switchaftervarbit55" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "switch-after-varbit.p4",
+        "line" : 48,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./switch-after-varbit.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}
+

--- a/examples/switch-after-varbit.p4
+++ b/examples/switch-after-varbit.p4
@@ -1,0 +1,60 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This example aims to test whether p4pktgen can vary the contents of
+ * fields that come after a variable length extraction. */
+
+header byte_hdr {
+    bit<8> value;
+}
+header variable_length_hdr {
+    varbit<256> content;
+}
+struct Header_t {
+    byte_hdr length;
+    variable_length_hdr field;
+    byte_hdr test_value;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        /* Extract length and variable length field */
+        b.extract(h.length);
+        b.extract(h.field, (bit<32>)h.length.value);
+
+        /* Extract field under test and branch depending on value. */
+        b.extract(h.test_value);
+        transition select(h.test_value.value) {
+            0x00: test_zero;
+            default: test_non_zero;
+        }
+    }
+
+    /* These two states do the same thing, but will result in different parser
+     * paths, therefore different test cases. */
+    state test_zero {
+        transition accept;
+    }
+    state test_non_zero {
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        h.length.value = 0;
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -24,7 +24,6 @@ class Config:
         self.max_test_cases_per_path = args.max_test_cases_per_path
         self.num_test_cases = args.num_test_cases
         self.try_least_used_branches_first = args.try_least_used_branches_first
-        self.hybrid_input = args.hybrid_input
         self.conditional_opt = args.conditional_opt
         self.table_opt = args.table_opt
         self.incremental = args.incremental
@@ -82,9 +81,6 @@ class Config:
 
     def get_try_least_used_branches_first(self):
         return self.try_least_used_branches_first
-
-    def get_hybrid_input(self):
-        return self.hybrid_input
 
     def get_conditional_opt(self):
         return self.conditional_opt

--- a/src/p4pktgen/core/packet.py
+++ b/src/p4pktgen/core/packet.py
@@ -3,77 +3,219 @@ from z3 import *
 import logging
 
 from p4pktgen.config import Config
+from p4pktgen.util.bitvec import equalize_bv_size, LShREq
 
-class Packet:
+class Packet(object):
     """The symbolic representation of a packet."""
 
     def __init__(self):
         # XXX: dynamic packet size
         self.max_packet_size = 4096
-        self.sym_packet = BitVec('packet', self.max_packet_size)
-        self.packet_size = BitVecVal(0, 32)
         self.packet_size_var = BitVec('packet_size', 32)
         self.max_length = None
 
-        self.const_size_vars = []
-        self.all_const_size = True
-        self.total_const_size = 0
+        # (length, var) tuples representing sequential extractions.
+        self.extract_vars = []
+
+        # Sub-list of the above, for varbit extractions only.
+        self.vl_extract_vars = []
+
+        # (start_offset, extract_index, var) tuples representing lookaheads,
+        # where extract_index is the index in self.extract_vars of the
+        # extraction at which the lookahead begins.  It is legal for
+        # extract_index to point immediately beyond the end of
+        # self.extract_vars, in which case the lookahead does not overlap with
+        # extractions.
+        self.lookaheads = []
+
+        # When generating packet constraints, this will be set to a variable
+        # modelling the portion of the packet overlapped by lookaheads but
+        # extending beyond the final extraction.
+        self.lookahead_tail = None
 
     def get_sym_packet_size(self):
         """Return the symbolic packet size."""
         return self.packet_size_var
 
-    def extract(self, start, size, lookahead=False):
-        start = simplify(start)
-        end = simplify(start + BitVecVal(size, 32))
-        self.update_packet_size(end)
+    def extract(self, start, field_size, read_size=None, lookahead=False):
+        """Return a new Z3 variable modelling a portion of the packet data."""
+        varbit = read_size is not None
+        if not varbit:
+            read_size = BitVecVal(field_size, 32)
 
-        if Config().get_hybrid_input() and not lookahead and self.all_const_size and is_const(
-                start) and is_const(end):
-            assert start == self.total_const_size
-            var = BitVec('packet{}'.format(len(self.const_size_vars)), size)
-            self.const_size_vars.append(var)
-            self.total_const_size += size
-            return var
+        if lookahead:
+            var = BitVec('lookahead{}'.format(len(self.lookaheads)), field_size)
+            self.lookaheads.append((simplify(start), len(self.extract_vars),
+                                    var))
         else:
-            self.all_const_size = False
-            rel_start = start - BitVecVal(self.total_const_size, 32)
-            return Extract(
-                size - 1, 0,
-                LShR(self.sym_packet,
-                     ZeroExt(self.max_packet_size - rel_start.size(),
-                             self.max_packet_size - rel_start - size)))
+            var = BitVec('packet{}'.format(len(self.extract_vars)), field_size)
+            self.extract_vars.append((read_size, var))
+            if varbit:
+                self.vl_extract_vars.append((read_size, var))
+        return var
 
-    def update_packet_size(self, end):
-        self.packet_size = simplify(
-            If(self.packet_size > end, self.packet_size, end))
+    def get_packet_constraints(self):
+        """Return a list of constraints arising from the nature of the
+        extractions that have been performed on the packet.
+        """
 
-    def get_length_constraint(self):
+        if self.extract_vars:
+            packet_size = simplify(sum(length
+                                       for (length, _) in self.extract_vars))
+        else:
+            packet_size = 0
+
+        # Constrain the packet length according to the lengths of the
+        # extractions and any external constraints imposed on the length.
         if self.max_length is None:
-            return self.packet_size_var == self.packet_size
+            constraints = [self.packet_size_var == packet_size]
         else:
-            return And(self.packet_size_var > self.packet_size,
-                       self.packet_size_var < self.max_length)
+            constraints = [And(self.packet_size_var > packet_size,
+                               self.packet_size_var < self.max_length)]
+
+        # Constrain variable-length extractions to the specified size.
+        for (read_size, var) in self.vl_extract_vars:
+            ones = BitVecVal(-1, var.size())
+            field_size_c = BitVecVal(var.size(), read_size.size())
+            # Technicality: extend var to be at least as wide as field_size_c
+            # so that they're compatible for constraints.
+            var_ext, _ = equalize_bv_size(var, field_size_c)
+            # Constrain that the variable modelling the variable-length
+            # extraction contains a value no larger than that specified by the
+            # specified length of that extraction.
+            constraints.append(ULE(var_ext,
+                                   LShREq(ones, field_size_c - read_size)))
+
+        # Create a packet-subfield for lookaheads that extend beyond the end
+        # of the final extraction.
+        assert self.lookahead_tail is None
+        if self.lookaheads:
+            max_la_size = max(var.size() for (_, _, var) in self.lookaheads)
+            self.lookahead_tail = BitVec('lookahead_tail', max_la_size)
+            lookahead_tail_len = BitVec('lookahead_tail_len', 32)
+            self.extract_vars.append((lookahead_tail_len, self.lookahead_tail))
+            constraints.append(ULE(lookahead_tail_len, max_la_size))
+            constraints.append(lookahead_tail_len & BitVecVal(0x7, 32) ==
+                               BitVecVal(0x0, 32))
+
+        # Impose equality constraints between lookaheads and overlapping
+        # extractions.
+        for (start, first_extract, var) in self.lookaheads:
+            # Track the maximum possible remaining length as an integer, and
+            # the exact remaining length as an expression.
+            max_remaining_length = var.size()
+            sym_remaining_length = BitVecVal(max_remaining_length, 32)
+
+            # A technicality: extend var to at least 32 bits so that we can do
+            # arithmetic with the bit-counting variables.
+            if max_remaining_length < 32:
+                mask = ZeroExt(32 - max_remaining_length,
+                               BitVecVal(-1, var.size()))
+                var = ZeroExt(32 - max_remaining_length, var)
+            else:
+                mask = BitVecVal(-1, var.size())
+
+            for extract_size, extract_var in self.extract_vars[first_extract:]:
+                # At the beginning of each loop iteration, the most significant
+                # of the sym_remaining_length bits in the lookahead is aligned
+                # with the most significant bit of the current extraction.
+
+                # If we've reached the lookahead-tail, we need to make sure
+                # that it's big enough.
+                if extract_var is self.lookahead_tail:
+                    constraints.append(UGE(extract_size, sym_remaining_length))
+
+                # How many bits overlap?
+                compare_bits = If(extract_size > sym_remaining_length,
+                                  sym_remaining_length, extract_size)
+                sym_remaining_length = simplify(sym_remaining_length -
+                                                compare_bits)
+
+                # Shift out the bits from the insignificant ends that we're not
+                # comparing.  Then the results must be equal.
+                extract_eq, lookahead_eq = equalize_bv_size(
+                    LShREq(extract_var, simplify(extract_size - compare_bits)),
+                    LShREq(var & mask, sym_remaining_length),
+                )
+                constraints.append(extract_eq == lookahead_eq)
+
+                # We can find an upper bound on the extractions with which the
+                # lookahead can overlap by keeping track of how many bits of
+                # fixed-length extractions we have consumed.
+                if (extract_size, extract_var) not in self.vl_extract_vars:
+                    max_remaining_length -= extract_var.size()
+                    if max_remaining_length <= 0:
+                        break
+
+                # Mask out the bits of the lookahead that we've consumed.
+                mask = simplify(LShREq(mask, compare_bits))
+
+        return constraints
 
     def set_max_length(self, max_length):
+        """Used to model explicit restrictions on the length of the packet
+        arising from the control path.
+        """
         self.max_length = max_length
 
     def get_payload_from_model(self, model):
-        # XXX: find a better way to do this
-        size = model[self.packet_size_var].as_long()
+        """Returns a byte array containing the packet data, reassembled from
+        the variables modelling the individual extractions and lookaheads.
+        """
+        hex_substrings = []
 
-        complete_packet = self.sym_packet
-        if len(self.const_size_vars) > 0:
-            complete_packet = Concat(self.const_size_vars + [complete_packet])
-        packet_model = model.eval(complete_packet, model_completion=True)
-        if packet_model is not None:
-            hex_str = '{0:x}'.format(packet_model.as_long())
-        else:
-            hex_str = ''
+        # Track respectively the number of bits and the value of those bits
+        # to carry into the next iteration.
+        (carry_width, carry_val) = (0, 0)
 
-        logging.debug(hex_str)
-        hex_str = hex_str.zfill(
-            (self.max_packet_size + self.total_const_size) // 4)
-        n_bytes = (size + 7) // 8
-        hex_str = hex_str[:n_bytes * 2]
+        for (read_width, var) in self.extract_vars:
+            var_expr = model.eval(var, model_completion=True)
+            if var_expr is None:
+                # This means that there was no suitable value for this
+                # variable, in which case we should return an empty packet,
+                # regardless of the values that might exist for other
+                # variables.
+                hex_substrings = []
+                break
+
+            val = var_expr.as_long()
+            width = model.eval(read_width, model_completion=True).as_long()
+            assert val < (1 << width)
+
+            assert carry_width < 4
+            if carry_width > 0:
+                # Carry in bits from the previous iteration.
+                val |= carry_val << width
+                width += carry_width
+                carry_width = 0
+
+            if width & 3:
+                # We have to hexify things a nybble at a time, so punt any
+                # left over bits at the less-signficiant end to the next
+                # iteration.
+                carry_width = width & 3
+                carry_val = val & ((1 << carry_width) - 1)
+                width -= carry_width
+                val >>= carry_width
+
+            assert width & 3 == 0 and val < (1 << width), \
+                   (val, width, carry_width, carry_val, hex_substrings)
+
+            if width == 0:
+                continue
+
+            substr = '{0:x}'.format(val).zfill(width // 4)
+            hex_substrings.append(substr)
+
+        # We require that the last extraction finish at a nybble boundary.
+        assert carry_width == 0
+
+        hex_str = ''.join(hex_substrings)
+
+        # Constraints on the packet size can mean that we need to extend
+        # the packet beyond the extractions.  Likewise, we must extend the
+        # packet if it doesn't finish on a byte boundary.
+        size = model.eval(self.packet_size_var, model_completion=True).as_long()
+        size = (size + 7) // 8
+        hex_str = hex_str.ljust(size * 2, '0')
         return bytearray.fromhex(hex_str)

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -86,12 +86,6 @@ def main():
         default=False,
         help='Record statistics', )
     parser.add_argument(
-        '--no-hybrid-input',
-        dest='hybrid_input',
-        action='store_false',
-        default=True,
-        help='Do not use the hybrid input representation')
-    parser.add_argument(
         '--no-conditional-opt',
         dest='conditional_opt',
         action='store_false',

--- a/src/p4pktgen/util/bitvec.py
+++ b/src/p4pktgen/util/bitvec.py
@@ -1,0 +1,13 @@
+"""Utility wrappers around some Z3 bitvector functionality."""
+
+import z3
+
+
+def equalize_bv_size(*bvs):
+    """Yields zero-extensions of the input bitvectors such that those
+    extensions all have equal and minimal width.
+    """
+    target_size = max(bv.size() for bv in bvs)
+    for bv in bvs:
+        yield (z3.ZeroExt(target_size - bv.size(), bv)
+               if bv.size() != target_size else bv)

--- a/src/p4pktgen/util/bitvec.py
+++ b/src/p4pktgen/util/bitvec.py
@@ -11,3 +11,10 @@ def equalize_bv_size(*bvs):
     for bv in bvs:
         yield (z3.ZeroExt(target_size - bv.size(), bv)
                if bv.size() != target_size else bv)
+
+
+def LShREq(val, shift):
+    """Morally equivalent to z3.LShR, but zero-extends its arguments as
+    necessary so that the shift is well-defined.
+    """
+    return z3.LShR(*equalize_bv_size(val, shift))

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -554,3 +554,21 @@ class CheckSystem:
             ('start', 'test_short', 'sink', (u'tbl_lookaheadbeyondextract53', u'lookaheadbeyondextract53')): TestPathResult.SUCCESS,
         }
         assert results == expected_results
+
+
+    def check_narrow_extractions(self):
+        # This test case checks that extractions that straddle nybble
+        # boundaries are handled correctly.
+        load_test_config()
+        results = run_test('examples/narrow-extractions.json')
+        expected_results = {
+            ('start', 'sink', (u'node_2', (True, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'tbl_narrowextractions44', u'narrowextractions44'), (u'node_4', (True, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'tbl_narrowextractions47', u'narrowextractions47'), (u'node_6', (True, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7'))), (u'tbl_narrowextractions50', u'narrowextractions50')): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (True, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'tbl_narrowextractions44', u'narrowextractions44'), (u'node_4', (True, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'tbl_narrowextractions47', u'narrowextractions47'), (u'node_6', (False, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7')))): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (True, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'tbl_narrowextractions44', u'narrowextractions44'), (u'node_4', (False, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'node_6', (True, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7'))), (u'tbl_narrowextractions50', u'narrowextractions50')): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (True, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'tbl_narrowextractions44', u'narrowextractions44'), (u'node_4', (False, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'node_6', (False, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7')))): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (False, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'node_4', (True, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'tbl_narrowextractions47', u'narrowextractions47'), (u'node_6', (True, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7'))), (u'tbl_narrowextractions50', u'narrowextractions50')): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (False, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'node_4', (True, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'tbl_narrowextractions47', u'narrowextractions47'), (u'node_6', (False, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7')))): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (False, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'node_4', (False, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'node_6', (True, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7'))), (u'tbl_narrowextractions50', u'narrowextractions50')): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'node_2', (False, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'node_4', (False, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'node_6', (False, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7')))): TestPathResult.SUCCESS,
+        }
+        assert results == expected_results

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -57,7 +57,6 @@ def load_test_config(no_packet_length_errs=True,
     config.max_test_cases_per_path = 1
     config.num_test_cases = None
     config.try_least_used_branches_first = False
-    config.hybrid_input = True
     config.conditional_opt = True
     config.table_opt = True
     config.incremental = True
@@ -532,7 +531,6 @@ class CheckSystem:
             lengths2.add(l2)
 
 
-    @pytest.mark.xfail(reason="Variable length extractions mask subsequent constant extractions")
     def check_extract_fixed_after_variable(self):
         # This test case checks that fixed-length extractions of regions
         # that follow immediately after a variably-extracted region are

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from p4pktgen.main import generate_test_cases, path_tuple
 from p4pktgen.config import Config
@@ -529,3 +530,17 @@ class CheckSystem:
             lengths1.add(l1)
             assert l2 not in lengths2
             lengths2.add(l2)
+
+
+    @pytest.mark.xfail(reason="Variable length extractions mask subsequent constant extractions")
+    def check_extract_fixed_after_variable(self):
+        # This test case checks that fixed-length extractions of regions
+        # that follow immediately after a variably-extracted region are
+        # handled correctly.
+        load_test_config()
+        results = run_test('examples/switch-after-varbit.json')
+        expected_results = {
+            ('start', 'test_non_zero', 'sink', (u'tbl_switchaftervarbit55', u'switchaftervarbit55')): TestPathResult.SUCCESS,
+            ('start', 'test_zero', 'sink', (u'tbl_switchaftervarbit55', u'switchaftervarbit55')): TestPathResult.SUCCESS,
+        }
+        assert results == expected_results

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -542,3 +542,15 @@ class CheckSystem:
             ('start', 'test_zero', 'sink', (u'tbl_switchaftervarbit55', u'switchaftervarbit55')): TestPathResult.SUCCESS,
         }
         assert results == expected_results
+
+
+    def check_lookahead_beyond_extract(self):
+        # This test case checks that lookaheads that extend beyond the final
+        # extraction are handled correctly.
+        load_test_config()
+        results = run_test('examples/lookahead-beyond-extract.json')
+        expected_results = {
+            ('start', 'test_long', 'sink', (u'tbl_lookaheadbeyondextract53', u'lookaheadbeyondextract53')): TestPathResult.SUCCESS,
+            ('start', 'test_short', 'sink', (u'tbl_lookaheadbeyondextract53', u'lookaheadbeyondextract53')): TestPathResult.SUCCESS,
+        }
+        assert results == expected_results


### PR DESCRIPTION
Split up the representation of the packet into separate fields.
This solves a bug with VL extractions and improves performance.