### PR TITLE
for-upstream/table-consolidation

### DIFF
--- a/examples/simple-table.json
+++ b/examples/simple-table.json
@@ -1,0 +1,298 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "abyte",
+      "id" : 2,
+      "fields" : [
+        ["data", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "a",
+      "id" : 2,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "x",
+      "id" : 3,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "a"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "x"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "simple-table.p4",
+        "line" : 33,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "ingress.noop",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.setx",
+      "id" : 1,
+      "runtime_data" : [
+        {
+          "name" : "val",
+          "bitwidth" : 8
+        }
+      ],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["x", "data"]
+            },
+            {
+              "type" : "runtime_data",
+              "value" : 0
+            }
+          ],
+          "source_info" : {
+            "filename" : "simple-table.p4",
+            "line" : 38,
+            "column" : 8,
+            "source_fragment" : "h.x.data = val"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "simple-table.p4",
+        "line" : 34,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "ingress.table1",
+      "tables" : [
+        {
+          "name" : "ingress.table1",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "simple-table.p4",
+            "line" : 41,
+            "column" : 10,
+            "source_fragment" : "table1"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "h.a.data",
+              "target" : ["a", "data"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0, 1],
+          "actions" : ["ingress.noop", "ingress.setx"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "ingress.noop" : null,
+            "ingress.setx" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "simple-table.p4",
+        "line" : 31,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./simple-table.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/simple-table.p4
+++ b/examples/simple-table.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* Applies a simple table with const default action.  Used for basic tests
+ * involving tables.
+ */
+
+
+header abyte {
+    bit<8> data;
+}
+
+struct Header_t {
+    abyte a;
+    abyte x;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.a);
+        b.extract(h.x);
+        transition accept;
+    }
+}
+
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    action noop() { }
+    action setx(bit<8> val) {
+        h.x.data = val;
+    }
+
+    table table1 {
+        key = { h.a.data: exact; }
+        actions = {
+            noop;
+            setx;
+        }
+        const default_action = noop();
+    }
+
+    apply {
+        table1.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/two-config-table.json
+++ b/examples/two-config-table.json
@@ -1,0 +1,461 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "abyte",
+      "id" : 2,
+      "fields" : [
+        ["data", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "a",
+      "id" : 2,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "x",
+      "id" : 3,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "a"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "x"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "two-config-table.p4",
+        "line" : 36,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "ingress.noop",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.setx",
+      "id" : 1,
+      "runtime_data" : [
+        {
+          "name" : "val",
+          "bitwidth" : 8
+        }
+      ],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["x", "data"]
+            },
+            {
+              "type" : "runtime_data",
+              "value" : 0
+            }
+          ],
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 41,
+            "column" : 8,
+            "source_fragment" : "h.x.data = val"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "twoconfigtable62",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["a", "data"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x02"
+            }
+          ],
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 62,
+            "column" : 12,
+            "source_fragment" : "h.a.data = 2"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "twoconfigtable65",
+      "id" : 3,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["a", "data"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x03"
+            }
+          ],
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 65,
+            "column" : 12,
+            "source_fragment" : "h.a.data = 3"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "two-config-table.p4",
+        "line" : 37,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "ingress.table1",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 44,
+            "column" : 10,
+            "source_fragment" : "table1"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "h.a.data",
+              "target" : ["a", "data"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0, 1],
+          "actions" : ["ingress.noop", "ingress.setx"],
+          "base_default_next" : "node_4",
+          "next_tables" : {
+            "ingress.noop" : "node_4",
+            "ingress.setx" : "node_4"
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_twoconfigtable62",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 62,
+            "column" : 21,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["twoconfigtable62"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "twoconfigtable62" : null
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_twoconfigtable65",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 65,
+            "column" : 21,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [3],
+          "actions" : ["twoconfigtable65"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "twoconfigtable65" : null
+          },
+          "default_entry" : {
+            "action_id" : 3,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 55,
+            "column" : 11,
+            "source_fragment" : "h.x.data == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["x", "data"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "true_next" : "ingress.table1",
+          "false_next" : "node_4"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "two-config-table.p4",
+            "line" : 61,
+            "column" : 11,
+            "source_fragment" : "h.x.data == 1"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["x", "data"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x01"
+              }
+            }
+          },
+          "true_next" : "tbl_twoconfigtable62",
+          "false_next" : "tbl_twoconfigtable65"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "two-config-table.p4",
+        "line" : 34,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./two-config-table.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/two-config-table.p4
+++ b/examples/two-config-table.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* Applies a table, the parameters of which will determine which branch of a
+ * conditional is then taken.  Assuming that each table action can only have one
+ * entry (a current limitation of table consolidated solving) this program will
+ * require two distinct table configurations in order to fully exercise.
+ * Additionally has some paths which do not use the table to check that these
+ * are grouped in with paths that do when doing consolidated solving. */
+
+header abyte {
+    bit<8> data;
+}
+
+struct Header_t {
+    abyte a;
+    abyte x;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.a);
+        b.extract(h.x);
+        transition accept;
+    }
+}
+
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    action noop() { }
+    action setx(bit<8> val) {
+        h.x.data = val;
+    }
+
+    table table1 {
+        key = { h.a.data: exact; }
+        actions = {
+            noop;
+            setx;
+        }
+        const default_action = noop();
+    }
+
+    apply {
+        /* If x==0, table may set it to a runtime parameter value */
+        if(h.x.data == 0) {
+            table1.apply();
+        }
+
+        /* If table1 was applied this block should require two table
+         * configurations to fully exercise */
+        if(h.x.data == 1) {
+            h.a.data = 2;
+        }
+        else {
+            h.a.data = 3;
+        }
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -30,6 +30,7 @@ class Config:
         self.random_tlubf = args.random_tlubf
         self.output_path = './test-case'
         self.extract_vl_variation = args.extract_vl_variation
+        self.consolidate_tables = args.consolidate_tables
 
     def get_debug(self):
         return self.debug
@@ -105,3 +106,9 @@ class Config:
                 self.extract_vl_variation.lower() == 'none':
             return None
         return self.extract_vl_variation
+
+    def get_consolidate_tables(self):
+        return self.consolidate_tables
+
+    def get_do_consolidate_tables(self):
+        return self.consolidate_tables is not None

--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -1,0 +1,423 @@
+import time
+import logging
+
+import z3
+
+from p4pktgen.config import Config
+from p4pktgen.core.test_cases import TestCaseBuilder
+from p4pktgen.core.test_cases import record_test_case
+from p4pktgen.core.packet import Packet
+from p4pktgen.util.statistics import Statistics
+
+
+def assert_sizes_equal(lhs_items, rhs_items):
+    lhs_sizes = [item.size() for item in lhs_items]
+    rhs_sizes = [item.size() for item in rhs_items]
+    assert lhs_sizes == rhs_sizes, (lhs_sizes, rhs_sizes)
+
+
+def var_is_fixed(var):
+    """Returns whether an expression is a fixed value.  e.g. BitVecVal"""
+    # z3.const means an expression that has no children. e.g. BitVec, BitVecVal
+    assert z3.is_const(var), var
+    # Unfixed variables are "uninterpreted consts". e.g. BitVec
+    return var.decl().kind() != z3.Z3_OP_UNINTERPRETED
+
+
+def path_specific_var(prefix, var, var_mapping):
+    """If var is not fixed, returns a renamed copy that can be constrained
+    without affecting the original var, or copies with different prefixes.
+    var_mapping caches all path specific variables."""
+    assert z3.is_const(var), var
+    if var_is_fixed(var):
+        # No ability or need to convert fixed values
+        return var
+    # Only currently need to support bitvecs, expand as needed.
+    assert z3.is_bv(var), var
+    return var_mapping.setdefault(
+        var, z3.BitVec(prefix + str(var), var.size()))
+
+
+def get_all_vars(expr):
+    """Returns all variables in the expression."""
+    if z3.is_const(expr):
+        if var_is_fixed(expr):
+            return set()
+        else:
+            return {expr}
+    assert expr.children()
+    child_vars = set()
+    for child_expr in expr.children():
+        child_vars |= get_all_vars(child_expr)
+    return child_vars
+
+
+def path_specific_expr(prefix, expr, var_mapping):
+    """Creates a path specific copy of an expression, substituting all variables
+    with path specific copies."""
+    assert z3.is_expr(expr), expr
+    if z3.is_const(expr):
+        return path_specific_var(prefix, expr, var_mapping)
+    else:
+        sub_map = {}
+        for var in get_all_vars(expr):
+            sub_map[var] = path_specific_var(prefix, var, var_mapping)
+        return z3.substitute(expr, sub_map.items())
+
+
+def path_specific_constraints(prefix, constraints, var_mapping):
+    """Creates duplicate constraints with all variables replaced with path
+    specific copies"""
+    new_constraints = []
+
+    for cs in constraints:
+        new_cs = [path_specific_expr(prefix, c, var_mapping) for c in cs]
+        new_constraints.append(new_cs)
+
+    return new_constraints
+
+
+def path_specific_packet(prefix, packet, var_mapping):
+    """Creates a path specific copy of a packet, whose variables have been
+    replaced with path specific copies.  Return values should only be used to
+    call 'get_payload_from_model', not for any further extractions."""
+    new_packet = Packet()
+
+    # Only need packet to call get_payload_from_model so only fill in these
+    # fields.
+    new_packet.packet_size_var = \
+        path_specific_var(prefix, packet.packet_size_var, var_mapping)
+    new_packet.extract_vars = \
+        [(path_specific_var(prefix, length, var_mapping),
+          path_specific_var(prefix, var, var_mapping))
+         for length, var in packet.extract_vars]
+
+    return new_packet
+
+
+class ConsolidatedSolver(object):
+    def __init__(self, json_file, pipeline, test_case_writer):
+        self.test_case_builder = TestCaseBuilder(json_file, pipeline)
+        self.test_case_writer = test_case_writer
+
+        self.solver = z3.SolverFor('QF_UFBV')
+        self.solver.push()
+
+        # TODO: A push/pop model for ConsolidatedSolvers would make it easier to
+        #  address complicated use-cases and help with "pending" constraints.
+        # path_data is a data structure containing whatever is needed by the
+        # child class' build_test_case implementation.
+        self.paths_data = []  # [ (path_id, path_data), ... ]
+
+    def reset(self):
+        self.solver.reset()
+        self.paths_data = []
+
+    def build_test_case(self, model, path_id, path_data):
+        raise NotImplementedError("Overwrite in child class.")
+
+    def solve(self):
+        start_time = time.time()
+        Statistics().solver_time.start()
+        solver_result = self.solver.check()
+        Statistics().num_solver_calls += 1
+        Statistics().solver_time.stop()
+        logging.debug("Checked %d paths, result=%s, %f seconds"
+                      % (len(self.paths_data), solver_result,
+                         time.time() - start_time))
+        return solver_result
+
+    def flush(self):
+        logging.info("Flushing %d paths"
+                     % (len(self.paths_data),))
+        if not self.paths_data:
+            # If no paths have been added then nothing to do
+            return
+
+        # If any paths have been added and not removed, they should already be
+        # solved satisfiably, if not this will raise an error.
+        model = self.solver.model()
+
+        max_test_cases = Config().get_num_test_cases()
+        for path_id, path_data in self.paths_data:
+            if Statistics().num_test_cases == max_test_cases:
+                break
+            # TODO: Consider moving solvers to a yield model
+            test_case, payloads = self.build_test_case(model, path_id, path_data)
+            self.test_case_writer.write(test_case, payloads)
+            Statistics().num_test_cases += 1
+
+        self.reset()
+
+    def _try_add_path(self, path_id, constraints, path_data):
+        self.paths_data.append((path_id, path_data))
+        self.solver.push()
+        for cs in constraints:
+            self.solver.add(z3.And(cs))
+
+        result = self.solve()
+        if result != z3.sat:
+            self.paths_data.pop()
+            self.solver.pop()
+
+        return result == z3.sat
+
+    def _add_path(self, path_id, constraints, path_data):
+        max_n_paths = Config().get_consolidate_tables()
+        if len(self.paths_data) == max_n_paths:
+            logging.info("Too many paths-per-solve")
+            self.flush()
+
+        if not self._try_add_path(path_id, constraints, path_data):
+            logging.info("Failed to add path %d"
+                         % (path_id,))
+            self.flush()
+            self.reset()
+            logging.info("Flushed existing paths, re-adding path %d"
+                         % (path_id,))
+            assert self._try_add_path(path_id, constraints, path_data)
+        else:
+            logging.info("Successfully added path %d"
+                         % (path_id,))
+
+    def add_path(self, *args, **kwargs):
+        # Child should package up path_data and call _add_path.
+        raise NotImplementedError("Overwrite in child class.")
+
+
+class TableConsolidatedSolver(ConsolidatedSolver):
+    # Consolidates table entries between paths to produce test cases that share
+    # table definitions as far as is possible.
+
+    # TODO: As a first cut this class has some limitations.
+    #  - Only one entry per action is supported, including the default action.
+    #    i.e. the default action cannot also be used for a "hit".
+    #  - Default values are treated the same as hit values, i.e. all paths with
+    #    a default action on a table will have same key values for that table.
+    #  - Tables with non-const defaults are not supported.
+    #  - All match types are supported, but are functionally equivalent to
+    #    'exact'.
+    #  - "pending" table_constraints are not forgotten on failure to add a path
+    #    because sym_vals set state cannot be "popped".  Paths in programs with
+    #    more actions in a table than the key-space allows could be rendered
+    #    unsolvable (triggering an assert).
+    #
+    # TODO: No hits with default action is a problem as p4pktgen will still try
+    #   and generate hit-entry paths with that action, so there will be two
+    #   default paths for each table (both hitting it via a MISS).
+    def __init__(self, json_file, pipeline, test_case_writer):
+        super(TableConsolidatedSolver, self).__init__(
+            json_file, pipeline, test_case_writer)
+
+        self.pipeline = pipeline
+        for table in self.pipeline.tables.values():
+            assert table.has_const_default_entry(), \
+                "Tables with non-const defaults are not currently supported"
+
+        # List of consolidated symbolic keys and symbolic action params for the
+        # table to use across all paths.
+        # Currently only allowing a single key per action.
+        self.table_action_sym_vals = {}  # {table_name: {action_name: (sym_key, sym_params)}}
+        # Filled with any pending entries during add path, empty otherwise
+        self.pending_table_action_sym_vals = {}
+
+        # Filled with [(cmd, cmd_data), ...] during flush, None otherwise.
+        self.table_setup_cmds = None
+
+    def reset(self):
+        super(TableConsolidatedSolver, self).reset()
+        self.table_action_sym_vals = {}
+        self.pending_table_action_sym_vals = {}
+        self.table_setup_cmds = None
+
+    def add_pending_table_sym_vals(self):
+        if self.pending_table_action_sym_vals is not None:
+            for table_name in self.pending_table_action_sym_vals.keys():
+                action_sym_vals = \
+                    self.table_action_sym_vals.setdefault(table_name, {})
+                pending_action_sym_vals = \
+                    self.pending_table_action_sym_vals[table_name]
+                for action_name, sym_vals \
+                        in pending_action_sym_vals.iteritems():
+                    assert action_name not in action_sym_vals
+                    action_sym_vals[action_name] = sym_vals
+        self.pending_table_action_sym_vals = {}
+
+    def build_table_entry_configs(self, model):
+        # One for each table entry, in no particular order
+        entry_configs = []
+
+        for table_name, action_sym_vals in self.table_action_sym_vals.items():
+            default_action, _ = \
+                self.pipeline.tables[table_name].get_default_action_name_id()
+
+            for action_name, (sym_key, sym_params) in action_sym_vals.items():
+                # All tables have const defaults and only one entry is allowed
+                # per action, therefore if action is the table's default it is
+                # only accessible as the table default action.
+                is_default = (action_name == default_action)
+                key_values = [model[element] for element in sym_key]
+
+                # TODO: Make this the name of the parameter, rather than the
+                #     mangled SMT variable name, only affects cmd_data (not cmd)
+                param_names_values = [(str(param), model[param])
+                                      for param in sym_params]
+
+                entry_config = self.test_case_builder.get_table_entry_config(
+                    table_name, action_name, is_default,
+                    key_values, param_names_values)
+
+                if entry_config is None:
+                    # Can happen if no config is required, i.e. const default.
+                    continue
+                entry_configs.append(entry_config)
+
+        return entry_configs
+
+    def build_test_case(self, model, path_id, path_data):
+        # Table entry configs will be same for every test_case before a reset.
+        # Build them all for first test-case of a flush.
+        if self.table_setup_cmds is None:
+            self.table_setup_cmds = [
+                self.test_case_builder.get_table_setup_cmd(entry_config)
+                for entry_config in self.build_table_entry_configs(model)
+            ]
+
+        sym_packet, expected_path, parser_path, control_path, \
+            is_complete_control_path, input_metadata, \
+            uninitialized_reads, invalid_header_writes, \
+            _table_data = path_data
+
+        result, test_case, payloads = \
+            self.test_case_builder.build(
+                model, sym_packet, expected_path, parser_path, control_path,
+                is_complete_control_path, path_id,
+                input_metadata, uninitialized_reads,
+                invalid_header_writes,
+                self.table_setup_cmds
+            )
+
+        # Should not be possible to get a bad test case from the model for any
+        # of the paths.
+        assert record_test_case(result, is_complete_control_path), \
+            (result, is_complete_control_path)
+        return test_case, payloads
+
+    def consolidated_vars(self, table_name, action_name,
+                          path_sym_key, path_sym_params):
+        # Returns a single set of key and param symbolic variables for each
+        # action-table combination, common across all paths.  Uses path-specific
+        # key and param symbolic variables as templates only.
+
+        # {action_name: (sym_key, sym_params)}
+        action_sym_vals = self.table_action_sym_vals.get(table_name, {})
+
+        # Check if there is already an entry for this action in this table
+        if action_name in action_sym_vals:
+            sym_key, sym_params = action_sym_vals[action_name]
+            assert_sizes_equal(sym_key, path_sym_key)
+            assert_sizes_equal(sym_params, path_sym_params)
+            return sym_key, sym_params, []
+
+        # Before creating a new entry, check key sizes are consistent with
+        # other entries for this table.
+        for other_sym_key, _ in action_sym_vals.values():
+            assert_sizes_equal(other_sym_key, path_sym_key)
+
+        prefix = 'consolidated_${}$.${}$.'.format(table_name, action_name)
+        # No existing entry for this action-table combination, create new
+        # symbolic variables.
+        sym_key = [z3.BitVec(prefix + 'key_{}'.format(i), element.size())
+                   for i, element in enumerate(path_sym_key)]
+
+        sym_params = [z3.BitVec(prefix + 'param_{}'.format(i), param.size())
+                      for i, param in enumerate(path_sym_params)]
+
+        constraints = []
+        for other_sym_key, _ in action_sym_vals.values():
+            constraints.append(z3.Or([
+                elem != other_elem
+                for elem, other_elem in zip(sym_key, other_sym_key)
+            ]))
+
+        # Add sym_vals to pending dict, will be added to main dict on add_path
+        # success
+        pending_action_sym_vals = \
+            self.pending_table_action_sym_vals.setdefault(table_name, {})
+        assert action_name not in pending_action_sym_vals
+        pending_action_sym_vals[action_name] = (sym_key, sym_params)
+
+        return sym_key, sym_params, constraints
+
+    def consolidated_constraints(self, table_name, action_name,
+                                 path_sym_key, path_sym_params):
+        sym_key, sym_params, constraints = self.consolidated_vars(
+            table_name, action_name, path_sym_key, path_sym_params)
+
+        # Supported key match types are ['exact', 'lpm', 'ternary', 'range'],
+        # but all currently produce tables with effectively exact matches.
+
+        # Constrain table keys for the path to match the consolidated keys
+        for sym_key_element, path_sym_key_element in zip(sym_key, path_sym_key):
+            constraints.append(sym_key_element == path_sym_key_element)
+
+        # Constrain action params for the path to match the consolidated params
+        for sym_param, path_sym_param in zip(sym_params, path_sym_params):
+            constraints.append(sym_param == path_sym_param)
+
+        return constraints
+
+    def _try_add_path(self, path_id, constraints, path_data):
+        table_data = path_data[8]
+
+        # Generate copy of path constraints with added constraints linking path
+        # table keys and parameters to consolidated variables.
+        new_constraints = list(constraints)
+        for table_name, (action_name, path_sym_key, path_sym_params) \
+                in table_data.iteritems():
+            new_constraints.extend(self.consolidated_constraints(
+                table_name, action_name,
+                path_sym_key, path_sym_params))
+
+        return super(TableConsolidatedSolver, self)._try_add_path(
+            path_id, new_constraints, path_data)
+
+    def add_path(self, path_id, constraints, context, sym_packet,
+                 expected_path, parser_path, control_path,
+                 is_complete_control_path):
+        prefix = 'path{}/'.format(path_id)
+        var_mapping = {}  # {old_param: new_param, ... }
+
+        new_constraints = \
+            path_specific_constraints(prefix, constraints, var_mapping)
+
+        new_sym_packet = \
+            path_specific_packet(prefix, sym_packet, var_mapping)
+
+        table_names = context.table_key_values.keys()
+        assert set(table_names) == set(context.table_runtime_data.keys())
+        table_data = {}
+        for table_name in table_names:
+            new_key_values = [path_specific_var(prefix, var, var_mapping)
+                              for var in context.table_key_values[table_name]]
+            new_runtime_data = [path_specific_var(prefix, var, var_mapping)
+                                for var in context.table_runtime_data[table_name]]
+            table_data[table_name] = (
+                context.table_action[table_name],
+                new_key_values,
+                new_runtime_data,
+            )
+
+        input_metadata = {
+            var_name: path_specific_var(prefix, var, var_mapping)
+            for var_name, var in context.input_metadata.iteritems()
+        }
+        path_data = (
+            new_sym_packet, expected_path, parser_path, control_path,
+            is_complete_control_path, input_metadata,
+            context.uninitialized_reads, context.invalid_header_writes,
+            table_data
+        )
+
+        self._add_path(path_id, new_constraints, path_data)
+        self.add_pending_table_sym_vals()

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -169,7 +169,8 @@ class Context:
 
     def get_table_key_values(self, model, table_name):
         return [
-            model.eval(sym_val) for sym_val in self.table_key_values[table_name]
+            model.eval(sym_val, model_completion=True)
+            for sym_val in self.table_key_values[table_name]
         ]
 
     def has_table_values(self, table_name):

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -211,3 +211,22 @@ class Context:
         logging.info('Variable constraints')
         for constraint in var_constraints:
             logging.info('\t{}'.format(constraint))
+
+    def get_stack_next_header_name(self, header_name):
+        # Each element in a stack needs a unique name, generate them in order
+        # of extraction.
+        name = '{}[{}]'.format(header_name, self.parsed_stacks[header_name])
+        self.parsed_stacks[header_name] += 1
+        return name
+
+    def set_valid_field(self, header_name):
+        # Even though the P4_16 isValid() method
+        # returns a boolean value, it appears that
+        # when p4c-bm2-ss compiles expressions like
+        # "if (ipv4.isValid())" into a JSON file, it
+        # compares the "ipv4.$valid$" field to a bit
+        # vector value of 1 with the == operator, thus
+        # effectively treating the "ipv4.$valid$" as
+        # if it is a bit<1> type.
+        self.set_field_value(header_name, '$valid$',
+                              BitVecVal(1, 1))

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -317,7 +317,7 @@ class PathSolver(object):
 
         start_time = time.time()
         result, test_case, payloads = \
-            self.test_case_builder.build(
+            self.test_case_builder.build_for_path(
                 context, model, self.sym_packet, expected_path,
                 parser_path, control_path, is_complete_control_path, count)
 

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -54,10 +54,14 @@ class PathSolver(object):
         # First element is constraints added by entire parser path.
         self.constraints = [[]]
 
+        # Increments whenever considering a control path (partial or complete)
+        self.path_id = -1
+
     def current_context(self):
         return self.context_history[-1]
 
     def push(self):
+        self.path_id += 1
         self.solver.push()
         self.context_history_lens.append(len(self.context_history))
         self.result_history.append([])
@@ -311,7 +315,7 @@ class PathSolver(object):
 
     def generate_test_case(self, expected_path,
                            parser_path, control_path, is_complete_control_path,
-                           source_info_to_node_name, count):
+                           source_info_to_node_name):
         context = self.current_context()
         model = self.solver.model() if self.solver_result == sat else None
 
@@ -319,7 +323,9 @@ class PathSolver(object):
         result, test_case, payloads = \
             self.test_case_builder.build_for_path(
                 context, model, self.sym_packet, expected_path,
-                parser_path, control_path, is_complete_control_path, count)
+                parser_path, control_path, is_complete_control_path,
+                self.path_id
+            )
 
         if Config().get_run_simple_switch():
             result = self.test_case_builder.run_simple_switch(

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -319,9 +319,13 @@ class PathSolver(object):
         result, test_case, payloads = \
             self.test_case_builder.build(
                 context, model, self.sym_packet, expected_path,
-                parser_path, control_path, is_complete_control_path,
-                source_info_to_node_name, count
-            )
+                parser_path, control_path, is_complete_control_path, count)
+
+        if Config().get_run_simple_switch():
+            result = self.test_case_builder.run_simple_switch(
+                expected_path, test_case, payloads,
+                is_complete_control_path, source_info_to_node_name)
+
         self.total_switch_time += time.time() - start_time
 
         self.result_history[-2].append(result)

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -1,0 +1,691 @@
+# TODO:
+#
+# - Position is a 32-bit integer right now. Smaller/larger?
+# - Move to smt-switch
+
+import copy
+import logging
+import time
+
+from enum import Enum
+from z3 import *
+
+from p4pktgen.config import Config
+from p4pktgen.core.context import Context
+from p4pktgen.core.packet import Packet
+from p4pktgen.core.translator import Translator
+from p4pktgen.hlir.transition import *
+from p4pktgen.hlir.type_value import *
+from p4pktgen.p4_hlir import *
+from p4pktgen.switch.simple_switch import SimpleSwitch
+from p4pktgen.util.statistics import Statistics, Timer
+from p4pktgen.util.table import Table
+
+TestPathResult = Enum(
+    'TestPathResult',
+    'SUCCESS NO_PACKET_FOUND TEST_FAILED UNINITIALIZED_READ INVALID_HEADER_WRITE PACKET_SHORTER_THAN_MIN'
+)
+
+
+# TBD: There is probably a better way to convert the params from
+# whatever type they are coming from the SMT solver, to something that
+# can be written out as JSON.  This seems to work, though.
+def model_value_to_long(model_val):
+    try:
+        return long(str(model_val))
+    except ValueError:
+        # This can happen when trying to convert values that are
+        # actually still variables in the model.  For example, when a
+        # key in a table is used that way, without first being
+        # initialized.
+        return None
+
+
+def source_info_to_dict(source_info):
+    if source_info is None:
+        return None
+    return OrderedDict(
+        [('filename', source_info.filename), ('line', source_info.line),
+         ('column', source_info.column), ('source_fragment',
+                                          source_info.source_fragment)])
+
+
+class PathSolver(object):
+    """Manages a z3 solver for paths through the graph.  Maintains state to
+    allow an incremental approach with backtracking and efficient solving of
+    graph edges."""
+
+    def __init__(self, json_file, hlir, pipeline):
+        if Config().get_run_simple_switch():
+            self.json_file = json_file
+        else:
+            self.json_file = None
+
+        self.solver = SolverFor('QF_UFBV')
+        self.solver.push()
+        self.solver_result = None
+        self.hlir = hlir
+        self.pipeline = pipeline
+        self.translator = Translator(hlir, pipeline)
+        self.context_history = [Context()]  # XXX: implement better mechanism
+        self.result_history = [[]]
+        self.context_history_lens = []
+        self.total_switch_time = 0.0
+
+        self.constraints = None if Config().get_incremental() else [[]]
+
+    def current_context(self):
+        return self.context_history[-1]
+
+    def push(self):
+        self.solver.push()
+        self.context_history_lens.append(len(self.context_history))
+        self.result_history.append([])
+
+        if self.constraints is not None:
+            self.constraints.append([])
+
+    def pop(self):
+        if Config().get_incremental():
+            self.solver.pop()
+
+        old_len = self.context_history_lens.pop()
+        self.context_history = self.context_history[:old_len]
+        self.result_history.pop()
+
+        if self.constraints is not None:
+            self.constraints.pop()
+
+    def cleanup(self):
+        pass
+
+    def table_set_default_cmd_string(self, table, action, params):
+        return ('{} {} {}'.format(table, action,
+                                  ' '.join([str(x) for x in params])))
+
+    def table_add_cmd_string(self, table, action, values, params, priority):
+        priority_str = ""
+        if priority:
+            priority_str = " %d" % (priority)
+        return ('{} {} {} => {}{}'.format(table, action, ' '.join(values),
+                                          ' '.join([str(x) for x in params]),
+                                          priority_str))
+
+    def init_context(self):
+        assert len(self.context_history) == 1
+        assert len(self.result_history) == 1
+
+        context = Context()
+
+        # Register the fields of all headers in the context
+        for header_name, header in self.hlir.headers.items():
+            for field_name, field in header.fields.items():
+                if field_name == '$valid$':
+                    # All valid bits in headers are 0 in the beginning
+                    context.insert(field, BitVecVal(0, 1))
+                else:
+                    context.register_field(field)
+
+        for stack_name, stack in self.hlir.header_stacks.items():
+            for i in range(stack.size):
+                context.set_field_value('{}[{}]'.format(stack_name, i),
+                                        '$valid$', BitVecVal(0, 1))
+
+        # XXX: refactor
+        context.set_field_value('standard_metadata', 'ingress_port',
+                                BitVec('$ingress_port$', 9))
+        context.set_field_value('standard_metadata', 'packet_length',
+                                self.sym_packet.get_sym_packet_size())
+        context.set_field_value('standard_metadata', 'instance_type',
+                                BitVec('$instance_type$', 32))
+        context.set_field_value('standard_metadata', 'egress_spec',
+                                BitVecVal(0, 9))
+
+        self.context_history[0] = context
+        self.result_history[0] = []
+
+    def generate_parser_constraints(self, parser_path):
+        parser_constraints_gen_timer = Timer('parser_constraints_gen')
+        parser_constraints_gen_timer.start()
+
+        if Config().get_incremental():
+            self.solver.pop()
+            self.solver.push()
+
+        self.sym_packet = Packet()
+        self.init_context()
+        constraints = []
+
+        # XXX: make this work for multiple parsers
+        parser = self.hlir.parsers['parser']
+        pos = BitVecVal(0, 32)
+        logging.info('path = {}'.format(' -> '.join(
+            [str(n) for n in list(parser_path)])))
+        for path_transition in parser_path:
+            assert isinstance(path_transition, ParserTransition) or isinstance(
+                path_transition, ParserOpTransition)
+
+            node = path_transition.src
+            next_node = path_transition.dst
+            logging.debug('{} -> {}\tpos = {}'.format(node, next_node, pos))
+            new_pos = pos
+            parse_state = parser.parse_states[node]
+
+            skip_select = False
+            for op_idx, parser_op in enumerate(parse_state.parser_ops):
+                fail = ''
+                if isinstance(
+                        path_transition, ParserOpTransition
+                ) and op_idx == path_transition.op_idx and path_transition.next_state == 'sink':
+                    fail = path_transition.error_str
+                    skip_select = True
+
+                new_pos = self.translator.parser_op_to_smt(
+                    self.current_context(), self.sym_packet, parser_op, fail,
+                    pos, new_pos, constraints)
+
+                if skip_select:
+                    break
+
+            if next_node == P4_HLIR.PACKET_TOO_SHORT:
+                # Packet needs to be at least one byte too short
+                self.sym_packet.set_max_length(simplify(new_pos - 8))
+                break
+
+            if not skip_select:
+                sym_transition_key = []
+                for transition_key_elem in parse_state.transition_key:
+                    if isinstance(transition_key_elem, TypeValueField):
+                        sym_transition_key.append(self.current_context(
+                        ).get_header_field(transition_key_elem.header_name,
+                                           transition_key_elem.header_field))
+                    elif isinstance(transition_key_elem, TypeValueStackField):
+                        sym_transition_key.append(
+                            self.current_context().get_last_header_field(
+                                transition_key_elem.header_name,
+                                transition_key_elem.header_field,
+                                self.hlir.get_header_stack(
+                                    transition_key_elem.header_name).size))
+                    else:
+                        raise Exception(
+                            'Transition key type not supported: {}'.format(
+                                transition_key_elem.__class__))
+
+                # XXX: is this check really necessary?
+                if len(sym_transition_key) > 0:
+                    # Make sure that we are not hitting any of the cases before the
+                    # case that we care about
+                    other_constraints = []
+                    for current_transition in parse_state.transitions:
+                        if current_transition != path_transition:
+                            other_constraints.append(
+                                self.translator.parser_transition_key_constraint(
+                                    sym_transition_key, current_transition.
+                                    value, current_transition.mask
+                                )
+                            )
+                        else:
+                            break
+
+                    constraints.append(Not(Or(other_constraints)))
+                    logging.debug(
+                        "Other constraints: {}".format(other_constraints))
+
+                    # The constraint for the case that we are interested in
+                    if path_transition.value is not None:
+                        constraint = self.translator.parser_transition_key_constraint(
+                            sym_transition_key, path_transition.value,
+                            path_transition.mask)
+                        constraints.append(constraint)
+
+                logging.debug(sym_transition_key)
+                pos = simplify(new_pos)
+
+        # XXX: workaround
+        self.current_context().set_field_value('meta_meta', 'packet_len',
+                                               self.sym_packet.packet_size_var)
+        constraints.extend(self.sym_packet.get_packet_constraints())
+        constraints.extend(self.current_context().get_name_constraints())
+        self.solver.add(And(constraints))
+
+        parser_constraints_gen_timer.stop()
+        logging.info('Generate parser constraints: %.3f sec' %
+                     (parser_constraints_gen_timer.get_time()))
+
+        Statistics().solver_time.start()
+        result = self.solver.check()
+        Statistics().num_solver_calls += 1
+        Statistics().solver_time.stop()
+
+        if not Config().get_incremental():
+            self.constraints[0] = constraints
+            self.solver.reset()
+
+        return result == sat
+
+    def log_model(self, model, context_history):
+        var_vals = defaultdict(lambda: [])
+        for i, context in enumerate(context_history):
+            for var, smt_var in context.var_to_smt_var.items():
+                if len(var_vals[var]) < i:
+                    # Add empty entries for the contexts where the variable
+                    # didn't exist
+                    var_vals[var] += [''] * (i - len(var_vals[var]))
+
+                if smt_var is None:
+                    var_vals[var].append('')
+                else:
+                    var_vals[var].append(str(model.eval(smt_var)))
+
+        table = Table()
+        table.add_rows([['.'.join(var)] + vals
+                        for var, vals in sorted(var_vals.items())])
+        logging.info('Model\n' + str(table))
+
+    def add_path_constraints(self, control_path):
+        assert len(control_path) == len(self.context_history_lens) \
+               or not Config().get_incremental()
+        self.context_history.append(copy.copy(self.current_context()))
+        context = self.current_context()
+        constraints = []
+
+        # XXX: very ugly to split parsing/control like that, need better solution
+        logging.info('control_path = {}'.format(control_path))
+
+        if len(control_path) > 0:
+            transition = control_path[-1]
+            constraints.extend(
+                self.translator.control_transition_constraints(context, transition))
+            self.context_history.append(copy.copy(self.current_context()))
+            context = self.current_context()
+
+        constraints.extend(context.get_name_constraints())
+        # XXX: Workaround for simple_switch issue
+        constraints.append(
+            Or(
+                ULT(context.get_header_field('standard_metadata', 'egress_spec'), 256),
+                context.get_header_field('standard_metadata', 'egress_spec') == 511
+            )
+        )
+
+        if not Config().get_incremental():
+            for cs in self.constraints:
+                self.solver.add(And(cs))
+            self.constraints[-1].extend(constraints)
+
+        # Construct and test the packet
+        # logging.debug(And(constraints))
+        self.solver.add(And(constraints))
+        self.solver_result = None
+
+    def try_quick_solve(self, control_path, is_complete_control_path):
+        context = self.current_context()
+        # If the last part of the path is a table with no const entries
+        # and the prefix of the current path is satisfiable, so is the new
+        # path
+        result = None
+        if len(control_path) > 0 \
+                and not is_complete_control_path \
+                and len(context.uninitialized_reads) == 0 \
+                and len(context.invalid_header_writes) == 0:
+            transition = control_path[-1]
+            if Config().get_table_opt() \
+                    and transition.transition_type == TransitionType.ACTION_TRANSITION:
+                assert transition.src in self.pipeline.tables
+                table = self.pipeline.tables[transition.src]
+                assert not table.has_const_entries()
+                result = TestPathResult.SUCCESS
+                self.result_history[-2].append(result)
+            elif Config().get_conditional_opt() \
+                    and transition.transition_type == TransitionType.BOOL_TRANSITION:
+                cond_history = self.result_history[-2]
+                if len(cond_history) > 0 \
+                        and cond_history[0] == TestPathResult.NO_PACKET_FOUND:
+                    assert len(cond_history) == 1
+                    result = TestPathResult.SUCCESS
+                    self.result_history[-2].append(result)
+        return result
+
+    def solve_path(self):
+        Statistics().solver_time.start()
+        self.solver_result = self.solver.check()
+        Statistics().num_solver_calls += 1
+        Statistics().solver_time.stop()
+        return self.solver_result
+
+    def generate_test_case(self, expected_path,
+                           parser_path, control_path, is_complete_control_path,
+                           source_info_to_node_name, count):
+        packet_hexstr = None
+        payload = None
+        ss_cli_setup_cmds = []
+        table_setup_cmd_data = []
+        uninitialized_read_data = None
+        invalid_header_write_data = None
+        actual_path_data = None
+        result = None
+
+        context = self.current_context()
+        start_time = time.time()
+        if self.solver_result != unsat:
+            model = self.solver.model()
+            if not Config().get_silent():
+                self.log_model(model, self.context_history)
+            payload = self.sym_packet.get_payload_from_model(model)
+
+            # Determine table configurations
+            table_configs = []
+            for t in control_path:
+                table_name = t.src
+                transition = t
+                if table_name in self.pipeline.tables \
+                        and context.has_table_values(table_name):
+                    runtime_data_values = []
+                    for i, runtime_param in enumerate(
+                            transition.action.runtime_data):
+                        runtime_data_values.append(
+                            (runtime_param.name,
+                             model[context.get_runtime_data_for_table_action(
+                                 table_name, transition.action.name,
+                                 runtime_param.name, i)]))
+                    sym_table_values = context.get_table_values(
+                        model, table_name)
+
+                    table = self.pipeline.tables[table_name]
+                    table_values_strs = []
+                    table_key_data = []
+                    table_entry_priority = None
+                    for table_key, sym_table_value in zip(
+                            table.key, sym_table_values):
+                        key_field_name = '.'.join(table_key.target)
+                        sym_table_value_long = model_value_to_long(
+                            sym_table_value)
+                        if table_key.match_type == 'lpm':
+                            bitwidth = context.get_header_field_size(
+                                table_key.target[0], table_key.target[1])
+                            table_values_strs.append(
+                                '{}/{}'.format(sym_table_value, bitwidth))
+                            table_key_data.append(
+                                OrderedDict([
+                                    ('match_kind', 'lpm'),
+                                    ('key_field_name', key_field_name),
+                                    ('value', sym_table_value_long),
+                                    ('prefix_length', bitwidth),
+                                ]))
+                        elif table_key.match_type == 'ternary':
+                            # Always use exact match mask, which is
+                            # represented in simple_switch_CLI as a 1 bit
+                            # in every bit position of the field.
+                            bitwidth = context.get_header_field_size(
+                                table_key.target[0], table_key.target[1])
+                            mask = (1 << bitwidth) - 1
+                            table_values_strs.append(
+                                '{}&&&{}'.format(sym_table_value, mask))
+                            table_entry_priority = 1
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'ternary'), (
+                                    'key_field_name', key_field_name), (
+                                                 'value', sym_table_value_long),
+                                             (
+                                                 'mask', mask)]))
+                        elif table_key.match_type == 'range':
+                            # Always use a range where the min and max
+                            # values are exactly the one desired value
+                            # generated.
+                            table_values_strs.append('{}->{}'.format(
+                                sym_table_value, sym_table_value))
+                            table_entry_priority = 1
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'range'), (
+                                    'key_field_name', key_field_name
+                                ), ('min_value', sym_table_value_long), (
+                                                 'max_value',
+                                                 sym_table_value_long)]))
+                        elif table_key.match_type == 'exact':
+                            table_values_strs.append(str(sym_table_value))
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'exact'), (
+                                    'key_field_name', key_field_name), (
+                                                 'value',
+                                                 sym_table_value_long)]))
+                        else:
+                            raise Exception('Match type {} not supported'.
+                                            format(table_key.match_type))
+
+                    logging.debug("table_name %s"
+                                  " table.default_entry.action_const %s" %
+                                  (table_name,
+                                   table.default_entry.action_const))
+                    if (len(table_values_strs) == 0
+                            and table.default_entry.action_const):
+                        # Then we cannot change the default action for the
+                        # table at run time, so don't remember any entry
+                        # for this table.
+                        pass
+                    else:
+                        table_configs.append(
+                            (table_name, transition, table_values_strs,
+                             table_key_data, runtime_data_values,
+                             table_entry_priority))
+
+            # Print table configuration
+            for table, action, values, key_data, params, priority in table_configs:
+                # XXX: inelegant
+                const_table = self.pipeline.tables[table].has_const_entries()
+
+                params2 = []
+                param_vals = []
+                for param_name, param_val in params:
+                    param_val = model_value_to_long(param_val)
+                    param_vals.append(param_val)
+                    params2.append(
+                        OrderedDict([('name', param_name), ('value', param_val)
+                                     ]))
+                if len(values) == 0 or const_table or action.default_entry:
+                    ss_cli_cmd = ('table_set_default ' +
+                                  self.table_set_default_cmd_string(
+                                      table, action.get_name(), param_vals))
+                    logging.info(ss_cli_cmd)
+                    table_setup_info = OrderedDict(
+                        [("command", "table_set_default"), ("table_name",
+                                                            table),
+                         ("action_name",
+                          action.get_name()), ("action_parameters", params2)])
+                else:
+                    ss_cli_cmd = ('table_add ' + self.table_add_cmd_string(
+                        table, action.get_name(), values, param_vals,
+                        priority))
+                    table_setup_info = OrderedDict(
+                        [("command", "table_add"), ("table_name",
+                                                    table), ("keys", key_data),
+                         ("action_name",
+                          action.get_name()), ("action_parameters", params2)])
+                    if priority is not None:
+                        table_setup_info['priority'] = priority
+                logging.info(ss_cli_cmd)
+                ss_cli_setup_cmds.append(ss_cli_cmd)
+                table_setup_cmd_data.append(table_setup_info)
+            packet_len_bytes = len(payload)
+            packet_hexstr = ''.join([('%02x' % (x)) for x in payload])
+            logging.info("packet (%d bytes) %s"
+                         "" % (packet_len_bytes, packet_hexstr))
+
+            if len(context.uninitialized_reads) != 0:
+                result = TestPathResult.UNINITIALIZED_READ
+                uninitialized_read_data = []
+                for uninitialized_read in context.uninitialized_reads:
+                    var_name, source_info = uninitialized_read
+                    logging.error('Uninitialized read of {} at {}'.format(
+                        var_name, source_info))
+                    uninitialized_read_data.append(
+                        OrderedDict([("variable_name", var_name), (
+                            "source_info", source_info_to_dict(source_info))]))
+            elif len(context.invalid_header_writes) != 0:
+                result = TestPathResult.INVALID_HEADER_WRITE
+                invalid_header_write_data = []
+                for invalid_header_write in context.invalid_header_writes:
+                    var_name, source_info = invalid_header_write
+                    logging.error('Invalid header write of {} at {}'.format(
+                        var_name, source_info))
+                    invalid_header_write_data.append(
+                        OrderedDict([("variable_name", var_name), (
+                            "source_info", source_info_to_dict(source_info))]))
+            elif len(payload) >= Config().get_min_packet_len_generated():
+                if Config().get_run_simple_switch() \
+                        and is_complete_control_path:
+                    extracted_path = self.test_packet(payload, table_configs,
+                                                      source_info_to_node_name)
+
+                    if is_complete_control_path:
+                        match = (expected_path == extracted_path)
+                    else:
+                        len1 = len(expected_path)
+                        len2 = len(extracted_path)
+                        match = (expected_path == extracted_path[0:len1]
+                                 ) and len1 <= len2
+                else:
+                    match = True
+                if match:
+                    logging.info('Test successful: {}'.format(expected_path))
+                    result = TestPathResult.SUCCESS
+                else:
+                    logging.error('Expected and actual path differ')
+                    logging.error('Expected: {}'.format(expected_path))
+                    logging.error('Actual:   {}'.format(extracted_path))
+                    result = TestPathResult.TEST_FAILED
+                    assert False
+            else:
+                result = TestPathResult.PACKET_SHORTER_THAN_MIN
+                logging.warning('Packet not sent (%d bytes is shorter than'
+                                ' minimum %d supported)' %
+                                (len(payload),
+                                 Config().get_min_packet_len_generated()))
+        else:
+            logging.info(
+                'Unable to find packet for path: {}'.format(expected_path))
+            result = TestPathResult.NO_PACKET_FOUND
+
+        self.total_switch_time += time.time() - start_time
+
+        if packet_hexstr is None:
+            input_packets = []
+        else:
+            input_metadata = {
+                '.'.join(var_name):
+                    model.eval(value, model_completion=True).as_long()
+                for (var_name, value) in context.input_metadata.iteritems()
+            }
+            input_packets = [
+                OrderedDict([
+                    # TBD: Currently we always send packets into port 0.
+                    # Should generalize that later.
+                    ("port", 0),
+                    ("packet_len_bytes", packet_len_bytes),
+                    ("packet_hexstr", packet_hexstr),
+                    ("input_metadata", input_metadata),
+                ])
+            ]
+
+        # TBD: Would be nice to get rid of u in front of strings on
+        # paths, e.g. u'node_2', u'p4_programs/demo1b.p4'.  Maybe it
+        # is beneficial to leave those in there for some reason, but I
+        # suspect a change in representation of parser paths and/or
+        # control paths could make bigger changes there such that we
+        # want to wait until those changes are made before mucking
+        # around with how they are returned.
+
+        # Instead of calling str() on every element of a path, might
+        # be nicer to convert them to a type that can be more easily
+        # represented as separate parts in JSON, e.g. nested lists or
+        # dicts of strings, numbers, booleans.
+        test_case = OrderedDict([
+            ("log_file_id", count),
+            ("result", result.name),
+            ("expected_path", map(str, expected_path)),
+            ("complete_path", is_complete_control_path),
+            ("ss_cli_setup_cmds", ss_cli_setup_cmds),
+            ("input_packets", input_packets),
+            # ("expected_output_packets", TBD),
+            ("parser_path_len", len(parser_path)),
+            ("ingress_path_len", len(control_path)),
+        ])
+        if uninitialized_read_data:
+            test_case["uninitialized_read_data"] = uninitialized_read_data
+        if invalid_header_write_data:
+            test_case["invalid_header_write_data"] = invalid_header_write_data
+        if actual_path_data:
+            test_case["actual_path"] = map(str, actual_path_data)
+
+        # Put details like these later in OrderedDict test_case,
+        # especialy long ones.  This makes the shorter and/or more
+        # essential information like that above come first, and
+        # together.
+
+        # Should be filled in by calling function, order will be maintained.
+        test_case["time_sec_generate_ingress_constraints"] = None
+        test_case["time_sec_solve"] = None
+        test_case["time_sec_simulate_packet"] = None
+
+        test_case["parser_path"] = map(str, parser_path)
+        test_case["ingress_path"] = map(str, control_path)
+        test_case["table_setup_cmd_data"] = table_setup_cmd_data
+
+        payloads = []
+        if payload:
+            payloads.append(payload)
+
+        self.result_history[-2].append(result)
+        return (result, test_case, payloads)
+
+    def constrain_last_extract_vl_lengths(self, condition):
+        """This function adds constraints to the solver preventing it from
+         selecting the same lengths for extract_vl operations that were selected
+         in the last solution.  Returns whether any constraints were added."""
+
+        # Should be called after a solve attempt, should not be called if it
+        # failed.
+        assert self.solver_result is not None and self.solver_result != unsat
+
+        context = self.current_context()
+        if not context.parsed_vl_extracts or condition is None:
+            return False
+
+        model = self.solver.model()
+        solution_sizes = []
+        for var, sym_size in context.parsed_vl_extracts.items():
+            solved_size = model[sym_size]
+            solution_sizes.append(sym_size == solved_size)
+
+        if condition == 'and':
+            self.solver.add(Not(And(solution_sizes)))
+        else:
+            assert condition == 'or'
+            self.solver.add(Not(Or(solution_sizes)))
+
+        return True
+
+    def test_packet(self, packet, table_configs, source_info_to_node_name):
+        """This function starts simple_switch, sends a packet to the switch and
+        returns the parser states that the packet traverses based on the output of
+        simple_switch."""
+
+        with SimpleSwitch(self.json_file) as switch:
+            for table, action, values, _, params, priority in table_configs:
+                # XXX: inelegant
+                const_table = self.pipeline.tables[table].has_const_entries()
+
+                # Extract values of parameters, without the names
+                param_vals = map(lambda x: x[1], params)
+                if len(values) == 0 or const_table or action.default_entry:
+                    switch.table_set_default(table, action.get_name(),
+                                             param_vals)
+                else:
+                    switch.table_add(table, action.get_name(), values,
+                                     param_vals, priority)
+
+            extracted_path = switch.send_and_check_only_1_packet(
+                packet, source_info_to_node_name)
+
+            switch.clear_tables()
+
+        return extracted_path

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -14,74 +14,12 @@ from p4pktgen.config import Config
 from p4pktgen.core.context import Context
 from p4pktgen.core.packet import Packet
 from p4pktgen.core.translator import Translator
+from p4pktgen.core.test_cases import TestCaseBuilder, TestPathResult
 from p4pktgen.hlir.transition import *
 from p4pktgen.hlir.type_value import *
 from p4pktgen.p4_hlir import *
-from p4pktgen.switch.simple_switch import SimpleSwitch
 from p4pktgen.util.statistics import Statistics, Timer
 from p4pktgen.util.table import Table
-
-TestPathResult = Enum(
-    'TestPathResult',
-    'SUCCESS NO_PACKET_FOUND TEST_FAILED UNINITIALIZED_READ INVALID_HEADER_WRITE PACKET_SHORTER_THAN_MIN'
-)
-
-
-# TBD: There is probably a better way to convert the params from
-# whatever type they are coming from the SMT solver, to something that
-# can be written out as JSON.  This seems to work, though.
-def model_value_to_long(model_val):
-    try:
-        return long(str(model_val))
-    except ValueError:
-        # This can happen when trying to convert values that are
-        # actually still variables in the model.  For example, when a
-        # key in a table is used that way, without first being
-        # initialized.
-        return None
-
-
-def source_info_to_dict(source_info):
-    if source_info is None:
-        return None
-    return OrderedDict(
-        [('filename', source_info.filename), ('line', source_info.line),
-         ('column', source_info.column), ('source_fragment',
-                                          source_info.source_fragment)])
-
-
-def table_set_default_cmd_string(table, action, params):
-    return ('{} {} {}'.format(table, action,
-                              ' '.join([str(x) for x in params])))
-
-
-def table_add_cmd_string(table, action, values, params, priority):
-    priority_str = ""
-    if priority:
-        priority_str = " %d" % (priority)
-    return ('{} {} {} => {}{}'.format(table, action, ' '.join(values),
-                                      ' '.join([str(x) for x in params]),
-                                      priority_str))
-
-
-def log_model(model, context_history):
-    var_vals = defaultdict(lambda: [])
-    for i, context in enumerate(context_history):
-        for var, smt_var in context.var_to_smt_var.items():
-            if len(var_vals[var]) < i:
-                # Add empty entries for the contexts where the variable
-                # didn't exist
-                var_vals[var] += [''] * (i - len(var_vals[var]))
-
-            if smt_var is None:
-                var_vals[var].append('')
-            else:
-                var_vals[var].append(str(model.eval(smt_var)))
-
-    table = Table()
-    table.add_rows([['.'.join(var)] + vals
-                    for var, vals in sorted(var_vals.items())])
-    logging.info('Model\n' + str(table))
 
 
 class PathSolver(object):
@@ -90,17 +28,13 @@ class PathSolver(object):
     graph edges."""
 
     def __init__(self, json_file, hlir, pipeline):
-        if Config().get_run_simple_switch():
-            self.json_file = json_file
-        else:
-            self.json_file = None
-
         self.solver = SolverFor('QF_UFBV')
         self.solver.push()
         self.solver_result = None
         self.hlir = hlir
         self.pipeline = pipeline
         self.translator = Translator(hlir, pipeline)
+        self.test_case_builder = TestCaseBuilder(json_file, pipeline)
         self.total_switch_time = 0.0
 
         # List of contexts along control path.  First element is context at
@@ -378,281 +312,17 @@ class PathSolver(object):
     def generate_test_case(self, expected_path,
                            parser_path, control_path, is_complete_control_path,
                            source_info_to_node_name, count):
-        packet_hexstr = None
-        payload = None
-        ss_cli_setup_cmds = []
-        table_setup_cmd_data = []
-        uninitialized_read_data = None
-        invalid_header_write_data = None
-        actual_path_data = None
-        result = None
-
         context = self.current_context()
+        model = self.solver.model() if self.solver_result == sat else None
+
         start_time = time.time()
-        if self.solver_result != unsat:
-            model = self.solver.model()
-            if not Config().get_silent():
-                log_model(model, self.context_history)
-            payload = self.sym_packet.get_payload_from_model(model)
-
-            # Determine table configurations
-            table_configs = []
-            for t in control_path:
-                table_name = t.src
-                transition = t
-                if table_name in self.pipeline.tables \
-                        and context.has_table_values(table_name):
-                    runtime_data_values = []
-                    for i, runtime_param in enumerate(
-                            transition.action.runtime_data):
-                        runtime_data_values.append(
-                            (runtime_param.name,
-                             model[context.get_table_runtime_data(table_name, i)]))
-                    table_key_values = context.get_table_key_values(
-                        model, table_name)
-
-                    table = self.pipeline.tables[table_name]
-                    table_key_values_strs = []
-                    table_key_data = []
-                    table_entry_priority = None
-                    for table_key, table_key_value in zip(
-                            table.key, table_key_values):
-                        key_field_name = '.'.join(table_key.target)
-                        sym_table_value_long = model_value_to_long(
-                            table_key_value)
-                        if table_key.match_type == 'lpm':
-                            bitwidth = context.get_header_field_size(
-                                table_key.target[0], table_key.target[1])
-                            table_key_values_strs.append(
-                                '{}/{}'.format(table_key_value, bitwidth))
-                            table_key_data.append(
-                                OrderedDict([
-                                    ('match_kind', 'lpm'),
-                                    ('key_field_name', key_field_name),
-                                    ('value', sym_table_value_long),
-                                    ('prefix_length', bitwidth),
-                                ]))
-                        elif table_key.match_type == 'ternary':
-                            # Always use exact match mask, which is
-                            # represented in simple_switch_CLI as a 1 bit
-                            # in every bit position of the field.
-                            bitwidth = context.get_header_field_size(
-                                table_key.target[0], table_key.target[1])
-                            mask = (1 << bitwidth) - 1
-                            table_key_values_strs.append(
-                                '{}&&&{}'.format(table_key_value, mask))
-                            table_entry_priority = 1
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'ternary'), (
-                                    'key_field_name', key_field_name), (
-                                                 'value', sym_table_value_long),
-                                             (
-                                                 'mask', mask)]))
-                        elif table_key.match_type == 'range':
-                            # Always use a range where the min and max
-                            # values are exactly the one desired value
-                            # generated.
-                            table_key_values_strs.append('{}->{}'.format(
-                                table_key_value, table_key_value))
-                            table_entry_priority = 1
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'range'), (
-                                    'key_field_name', key_field_name
-                                ), ('min_value', sym_table_value_long), (
-                                                 'max_value',
-                                                 sym_table_value_long)]))
-                        elif table_key.match_type == 'exact':
-                            table_key_values_strs.append(str(table_key_value))
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'exact'), (
-                                    'key_field_name', key_field_name), (
-                                                 'value',
-                                                 sym_table_value_long)]))
-                        else:
-                            raise Exception('Match type {} not supported'.
-                                            format(table_key.match_type))
-
-                    logging.debug("table_name %s"
-                                  " table.default_entry.action_const %s" %
-                                  (table_name,
-                                   table.default_entry.action_const))
-                    if (len(table_key_values_strs) == 0
-                            and table.default_entry.action_const):
-                        # Then we cannot change the default action for the
-                        # table at run time, so don't remember any entry
-                        # for this table.
-                        pass
-                    else:
-                        table_configs.append(
-                            (table_name, transition, table_key_values_strs,
-                             table_key_data, runtime_data_values,
-                             table_entry_priority))
-
-            # Print table configuration
-            for table, action, values, key_data, params, priority in table_configs:
-                # XXX: inelegant
-                const_table = self.pipeline.tables[table].has_const_entries()
-
-                params2 = []
-                param_vals = []
-                for param_name, param_val in params:
-                    param_val = model_value_to_long(param_val)
-                    param_vals.append(param_val)
-                    params2.append(
-                        OrderedDict([('name', param_name), ('value', param_val)
-                                     ]))
-                if len(values) == 0 or const_table or action.default_entry:
-                    ss_cli_cmd = ('table_set_default ' +
-                                  table_set_default_cmd_string(
-                                      table, action.get_name(), param_vals))
-                    logging.info(ss_cli_cmd)
-                    table_setup_info = OrderedDict(
-                        [("command", "table_set_default"), ("table_name",
-                                                            table),
-                         ("action_name",
-                          action.get_name()), ("action_parameters", params2)])
-                else:
-                    ss_cli_cmd = ('table_add ' + table_add_cmd_string(
-                        table, action.get_name(), values, param_vals,
-                        priority))
-                    table_setup_info = OrderedDict(
-                        [("command", "table_add"), ("table_name",
-                                                    table), ("keys", key_data),
-                         ("action_name",
-                          action.get_name()), ("action_parameters", params2)])
-                    if priority is not None:
-                        table_setup_info['priority'] = priority
-                logging.info(ss_cli_cmd)
-                ss_cli_setup_cmds.append(ss_cli_cmd)
-                table_setup_cmd_data.append(table_setup_info)
-            packet_len_bytes = len(payload)
-            packet_hexstr = ''.join([('%02x' % (x)) for x in payload])
-            logging.info("packet (%d bytes) %s"
-                         "" % (packet_len_bytes, packet_hexstr))
-
-            if len(context.uninitialized_reads) != 0:
-                result = TestPathResult.UNINITIALIZED_READ
-                uninitialized_read_data = []
-                for uninitialized_read in context.uninitialized_reads:
-                    var_name, source_info = uninitialized_read
-                    logging.error('Uninitialized read of {} at {}'.format(
-                        var_name, source_info))
-                    uninitialized_read_data.append(
-                        OrderedDict([("variable_name", var_name), (
-                            "source_info", source_info_to_dict(source_info))]))
-            elif len(context.invalid_header_writes) != 0:
-                result = TestPathResult.INVALID_HEADER_WRITE
-                invalid_header_write_data = []
-                for invalid_header_write in context.invalid_header_writes:
-                    var_name, source_info = invalid_header_write
-                    logging.error('Invalid header write of {} at {}'.format(
-                        var_name, source_info))
-                    invalid_header_write_data.append(
-                        OrderedDict([("variable_name", var_name), (
-                            "source_info", source_info_to_dict(source_info))]))
-            elif len(payload) >= Config().get_min_packet_len_generated():
-                if Config().get_run_simple_switch() \
-                        and is_complete_control_path:
-                    extracted_path = self.test_packet(payload, table_configs,
-                                                      source_info_to_node_name)
-
-                    if is_complete_control_path:
-                        match = (expected_path == extracted_path)
-                    else:
-                        len1 = len(expected_path)
-                        len2 = len(extracted_path)
-                        match = (expected_path == extracted_path[0:len1]
-                                 ) and len1 <= len2
-                else:
-                    match = True
-                if match:
-                    logging.info('Test successful: {}'.format(expected_path))
-                    result = TestPathResult.SUCCESS
-                else:
-                    logging.error('Expected and actual path differ')
-                    logging.error('Expected: {}'.format(expected_path))
-                    logging.error('Actual:   {}'.format(extracted_path))
-                    result = TestPathResult.TEST_FAILED
-                    assert False
-            else:
-                result = TestPathResult.PACKET_SHORTER_THAN_MIN
-                logging.warning('Packet not sent (%d bytes is shorter than'
-                                ' minimum %d supported)' %
-                                (len(payload),
-                                 Config().get_min_packet_len_generated()))
-        else:
-            logging.info(
-                'Unable to find packet for path: {}'.format(expected_path))
-            result = TestPathResult.NO_PACKET_FOUND
-
+        result, test_case, payloads = \
+            self.test_case_builder.build(
+                context, model, self.sym_packet, expected_path,
+                parser_path, control_path, is_complete_control_path,
+                source_info_to_node_name, count
+            )
         self.total_switch_time += time.time() - start_time
-
-        if packet_hexstr is None:
-            input_packets = []
-        else:
-            input_metadata = {
-                '.'.join(var_name):
-                    model.eval(value, model_completion=True).as_long()
-                for (var_name, value) in context.input_metadata.iteritems()
-            }
-            input_packets = [
-                OrderedDict([
-                    # TBD: Currently we always send packets into port 0.
-                    # Should generalize that later.
-                    ("port", 0),
-                    ("packet_len_bytes", packet_len_bytes),
-                    ("packet_hexstr", packet_hexstr),
-                    ("input_metadata", input_metadata),
-                ])
-            ]
-
-        # TBD: Would be nice to get rid of u in front of strings on
-        # paths, e.g. u'node_2', u'p4_programs/demo1b.p4'.  Maybe it
-        # is beneficial to leave those in there for some reason, but I
-        # suspect a change in representation of parser paths and/or
-        # control paths could make bigger changes there such that we
-        # want to wait until those changes are made before mucking
-        # around with how they are returned.
-
-        # Instead of calling str() on every element of a path, might
-        # be nicer to convert them to a type that can be more easily
-        # represented as separate parts in JSON, e.g. nested lists or
-        # dicts of strings, numbers, booleans.
-        test_case = OrderedDict([
-            ("log_file_id", count),
-            ("result", result.name),
-            ("expected_path", map(str, expected_path)),
-            ("complete_path", is_complete_control_path),
-            ("ss_cli_setup_cmds", ss_cli_setup_cmds),
-            ("input_packets", input_packets),
-            # ("expected_output_packets", TBD),
-            ("parser_path_len", len(parser_path)),
-            ("ingress_path_len", len(control_path)),
-        ])
-        if uninitialized_read_data:
-            test_case["uninitialized_read_data"] = uninitialized_read_data
-        if invalid_header_write_data:
-            test_case["invalid_header_write_data"] = invalid_header_write_data
-        if actual_path_data:
-            test_case["actual_path"] = map(str, actual_path_data)
-
-        # Put details like these later in OrderedDict test_case,
-        # especialy long ones.  This makes the shorter and/or more
-        # essential information like that above come first, and
-        # together.
-
-        # Should be filled in by calling function, order will be maintained.
-        test_case["time_sec_generate_ingress_constraints"] = None
-        test_case["time_sec_solve"] = None
-        test_case["time_sec_simulate_packet"] = None
-
-        test_case["parser_path"] = map(str, parser_path)
-        test_case["ingress_path"] = map(str, control_path)
-        test_case["table_setup_cmd_data"] = table_setup_cmd_data
-
-        payloads = []
-        if payload:
-            payloads.append(payload)
 
         self.result_history[-2].append(result)
         return (result, test_case, payloads)
@@ -683,29 +353,3 @@ class PathSolver(object):
             self.solver.add(Not(Or(solution_sizes)))
 
         return True
-
-    def test_packet(self, packet, table_configs, source_info_to_node_name):
-        """This function starts simple_switch, sends a packet to the switch and
-        returns the parser states that the packet traverses based on the output of
-        simple_switch."""
-
-        with SimpleSwitch(self.json_file) as switch:
-            for table, action, values, _, params, priority in table_configs:
-                # XXX: inelegant
-                const_table = self.pipeline.tables[table].has_const_entries()
-
-                # Extract values of parameters, without the names
-                param_vals = map(lambda x: x[1], params)
-                if len(values) == 0 or const_table or action.default_entry:
-                    switch.table_set_default(table, action.get_name(),
-                                             param_vals)
-                else:
-                    switch.table_add(table, action.get_name(), values,
-                                     param_vals, priority)
-
-            extracted_path = switch.send_and_check_only_1_packet(
-                packet, source_info_to_node_name)
-
-            switch.clear_tables()
-
-        return extracted_path

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -9,7 +9,7 @@ import random
 from enum import Enum
 
 from p4pktgen.config import Config
-from p4pktgen.core.solver import TestPathResult
+from p4pktgen.core.test_cases import TestPathResult
 from p4pktgen.util.graph import GraphVisitor, VisitResult
 from p4pktgen.util.statistics import Statistics
 from p4pktgen.hlir.transition import ActionTransition, ParserTransition

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -84,7 +84,6 @@ class PathCoverageGraphVisitor(GraphVisitor):
         self.path_solver = path_solver
         self.parser_path = parser_path
         self.source_info_to_node_name = source_info_to_node_name
-        self.path_count = 0
         self.results = results
         self.test_case_writer = test_case_writer
         self.stats_per_traversal = defaultdict(int)
@@ -93,13 +92,13 @@ class PathCoverageGraphVisitor(GraphVisitor):
         return edges
 
     def generate_test_case(self, control_path, is_complete_control_path):
-        self.path_count += 1
         self.path_solver.push()
 
         expected_path = self.path_solver.translator.expected_path(self.parser_path, control_path)
+        path_id = self.path_solver.path_id
 
         logging_str = "%d Exp path (len %d+%d=%d) complete_path %s: %s" % \
-            (self.path_count, len(self.parser_path), len(control_path),
+            (path_id, len(self.parser_path), len(control_path),
              len(self.parser_path) + len(control_path),
              is_complete_control_path, expected_path)
         logging.info("")
@@ -134,7 +133,6 @@ class PathCoverageGraphVisitor(GraphVisitor):
                 control_path=control_path,
                 is_complete_control_path=is_complete_control_path,
                 source_info_to_node_name=self.source_info_to_node_name,
-                count=self.path_count,
             )
             time5 = time.time()
 

--- a/src/p4pktgen/core/test_cases.py
+++ b/src/p4pktgen/core/test_cases.py
@@ -205,7 +205,7 @@ class TestCaseBuilder(object):
     @staticmethod
     def build(
             model, sym_packet, expected_path, parser_path, control_path,
-            is_complete_control_path, count, input_metadata,
+            is_complete_control_path, path_id, input_metadata,
             uninitialized_reads, invalid_header_writes, table_config):
         """Should take only explicit references to all variables to ensure that
         none are missed when separating paths for consolidated solving."""
@@ -298,7 +298,7 @@ class TestCaseBuilder(object):
         # represented as separate parts in JSON, e.g. nested lists or
         # dicts of strings, numbers, booleans.
         test_case = OrderedDict([
-            ("log_file_id", count),
+            ("log_file_id", path_id),
             ("result", result.name),
             ("expected_path", map(str, expected_path)),
             ("complete_path", is_complete_control_path),
@@ -337,10 +337,10 @@ class TestCaseBuilder(object):
 
     def build_for_path(self, context, model, sym_packet, expected_path,
                        parser_path, control_path, is_complete_control_path,
-                       count):
+                       path_id):
         return self.build(
             model, sym_packet, expected_path, parser_path, control_path,
-            is_complete_control_path, count,
+            is_complete_control_path, path_id,
             context.input_metadata, context.uninitialized_reads,
             context.invalid_header_writes,
             self.table_config_for_path(context, model, control_path)

--- a/src/p4pktgen/core/test_cases.py
+++ b/src/p4pktgen/core/test_cases.py
@@ -1,0 +1,361 @@
+import os
+import logging
+import tempfile
+
+from enum import Enum
+
+from collections import OrderedDict
+
+from p4pktgen.config import Config
+from p4pktgen.switch.simple_switch import SimpleSwitch
+
+
+TestPathResult = Enum(
+    'TestPathResult',
+    'SUCCESS NO_PACKET_FOUND TEST_FAILED UNINITIALIZED_READ INVALID_HEADER_WRITE PACKET_SHORTER_THAN_MIN'
+)
+
+
+# TBD: There is probably a better way to convert the params from
+# whatever type they are coming from the SMT solver, to something that
+# can be written out as JSON.  This seems to work, though.
+def model_value_to_long(model_val):
+    try:
+        return long(str(model_val))
+    except ValueError:
+        # This can happen when trying to convert values that are
+        # actually still variables in the model.  For example, when a
+        # key in a table is used that way, without first being
+        # initialized.
+        return None
+
+
+def source_info_to_dict(source_info):
+    if source_info is None:
+        return None
+    return OrderedDict(
+        [('filename', source_info.filename), ('line', source_info.line),
+         ('column', source_info.column), ('source_fragment',
+                                          source_info.source_fragment)])
+
+
+def table_set_default_cmd_string(table, action, params):
+    return ('{} {} {}'.format(table, action,
+                              ' '.join([str(x) for x in params])))
+
+
+def table_add_cmd_string(table, action, values, params, priority):
+    priority_str = ""
+    if priority:
+        priority_str = " %d" % (priority)
+    return ('{} {} {} => {}{}'.format(table, action, ' '.join(values),
+                                      ' '.join([str(x) for x in params]),
+                                      priority_str))
+
+
+class TestCaseBuilder(object):
+    def __init__(self, json_file, pipeline):
+        if Config().get_run_simple_switch():
+            self.json_file = json_file
+        else:
+            self.json_file = None
+        self.pipeline = pipeline
+
+    def build(self, context, model, sym_packet, expected_path,
+              parser_path, control_path, is_complete_control_path,
+              source_info_to_node_name, count):
+        packet_hexstr = None
+        payload = None
+        ss_cli_setup_cmds = []
+        table_setup_cmd_data = []
+        uninitialized_read_data = None
+        invalid_header_write_data = None
+        actual_path_data = None
+        result = None
+
+        if model is not None:
+            payload = sym_packet.get_payload_from_model(model)
+
+            # Determine table configurations
+            table_configs = []
+            for t in control_path:
+                table_name = t.src
+                transition = t
+                if table_name in self.pipeline.tables \
+                        and context.has_table_values(table_name):
+                    runtime_data_values = []
+                    for i, runtime_param in enumerate(
+                            transition.action.runtime_data):
+                        runtime_data_values.append(
+                            (runtime_param.name,
+                             model[context.get_table_runtime_data(table_name, i)]))
+                    table_key_values = context.get_table_key_values(
+                        model, table_name)
+
+                    table = self.pipeline.tables[table_name]
+                    table_key_values_strs = []
+                    table_key_data = []
+                    table_entry_priority = None
+                    for table_key, table_key_value in zip(
+                            table.key, table_key_values):
+                        key_field_name = '.'.join(table_key.target)
+                        sym_table_value_long = model_value_to_long(
+                            table_key_value)
+                        if table_key.match_type == 'lpm':
+                            bitwidth = context.get_header_field_size(
+                                table_key.target[0], table_key.target[1])
+                            table_key_values_strs.append(
+                                '{}/{}'.format(table_key_value, bitwidth))
+                            table_key_data.append(
+                                OrderedDict([
+                                    ('match_kind', 'lpm'),
+                                    ('key_field_name', key_field_name),
+                                    ('value', sym_table_value_long),
+                                    ('prefix_length', bitwidth),
+                                ]))
+                        elif table_key.match_type == 'ternary':
+                            # Always use exact match mask, which is
+                            # represented in simple_switch_CLI as a 1 bit
+                            # in every bit position of the field.
+                            bitwidth = context.get_header_field_size(
+                                table_key.target[0], table_key.target[1])
+                            mask = (1 << bitwidth) - 1
+                            table_key_values_strs.append(
+                                '{}&&&{}'.format(table_key_value, mask))
+                            table_entry_priority = 1
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'ternary'), (
+                                    'key_field_name', key_field_name), (
+                                                 'value', sym_table_value_long),
+                                             (
+                                                 'mask', mask)]))
+                        elif table_key.match_type == 'range':
+                            # Always use a range where the min and max
+                            # values are exactly the one desired value
+                            # generated.
+                            table_key_values_strs.append('{}->{}'.format(
+                                table_key_value, table_key_value))
+                            table_entry_priority = 1
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'range'), (
+                                    'key_field_name', key_field_name
+                                ), ('min_value', sym_table_value_long), (
+                                                 'max_value',
+                                                 sym_table_value_long)]))
+                        elif table_key.match_type == 'exact':
+                            table_key_values_strs.append(str(table_key_value))
+                            table_key_data.append(
+                                OrderedDict([('match_kind', 'exact'), (
+                                    'key_field_name', key_field_name), (
+                                    'value', sym_table_value_long)]))
+                        else:
+                            raise Exception('Match type {} not supported'.
+                                            format(table_key.match_type))
+
+                    logging.debug("table_name %s"
+                                  " table.default_entry.action_const %s" %
+                                  (table_name,
+                                   table.default_entry.action_const))
+                    if (len(table_key_values_strs) == 0
+                            and table.default_entry.action_const):
+                        # Then we cannot change the default action for the
+                        # table at run time, so don't remember any entry
+                        # for this table.
+                        pass
+                    else:
+                        table_configs.append(
+                            (table_name, transition, table_key_values_strs,
+                             table_key_data, runtime_data_values,
+                             table_entry_priority))
+
+            # Print table configuration
+            for table, action, values, key_data, params, priority in table_configs:
+                # XXX: inelegant
+                const_table = self.pipeline.tables[table].has_const_entries()
+
+                params2 = []
+                param_vals = []
+                for param_name, param_val in params:
+                    param_val = model_value_to_long(param_val)
+                    param_vals.append(param_val)
+                    params2.append(
+                        OrderedDict([('name', param_name), ('value', param_val)
+                                     ]))
+                if len(values) == 0 or const_table or action.default_entry:
+                    ss_cli_cmd = ('table_set_default ' +
+                                  table_set_default_cmd_string(
+                                      table, action.get_name(), param_vals))
+                    logging.info(ss_cli_cmd)
+                    table_setup_info = OrderedDict(
+                        [("command", "table_set_default"), ("table_name",
+                                                            table),
+                         ("action_name",
+                          action.get_name()), ("action_parameters", params2)])
+                else:
+                    ss_cli_cmd = ('table_add ' + table_add_cmd_string(
+                        table, action.get_name(), values, param_vals,
+                        priority))
+                    table_setup_info = OrderedDict(
+                        [("command", "table_add"), ("table_name",
+                                                    table), ("keys", key_data),
+                         ("action_name",
+                          action.get_name()), ("action_parameters", params2)])
+                    if priority is not None:
+                        table_setup_info['priority'] = priority
+                logging.info(ss_cli_cmd)
+                ss_cli_setup_cmds.append(ss_cli_cmd)
+                table_setup_cmd_data.append(table_setup_info)
+            packet_len_bytes = len(payload)
+            packet_hexstr = ''.join([('%02x' % (x)) for x in payload])
+            logging.info("packet (%d bytes) %s"
+                         "" % (packet_len_bytes, packet_hexstr))
+
+            if len(context.uninitialized_reads) != 0:
+                result = TestPathResult.UNINITIALIZED_READ
+                uninitialized_read_data = []
+                for uninitialized_read in context.uninitialized_reads:
+                    var_name, source_info = uninitialized_read
+                    logging.error('Uninitialized read of {} at {}'.format(
+                        var_name, source_info))
+                    uninitialized_read_data.append(
+                        OrderedDict([("variable_name", var_name), (
+                            "source_info", source_info_to_dict(source_info))]))
+            elif len(context.invalid_header_writes) != 0:
+                result = TestPathResult.INVALID_HEADER_WRITE
+                invalid_header_write_data = []
+                for invalid_header_write in context.invalid_header_writes:
+                    var_name, source_info = invalid_header_write
+                    logging.error('Invalid header write of {} at {}'.format(
+                        var_name, source_info))
+                    invalid_header_write_data.append(
+                        OrderedDict([("variable_name", var_name), (
+                            "source_info", source_info_to_dict(source_info))]))
+            elif len(payload) >= Config().get_min_packet_len_generated():
+                if Config().get_run_simple_switch() \
+                        and is_complete_control_path:
+                    extracted_path = self.test_packet(payload, table_configs,
+                                                      source_info_to_node_name)
+
+                    if is_complete_control_path:
+                        match = (expected_path == extracted_path)
+                    else:
+                        len1 = len(expected_path)
+                        len2 = len(extracted_path)
+                        match = (expected_path == extracted_path[0:len1]
+                                 ) and len1 <= len2
+                else:
+                    match = True
+                if match:
+                    logging.info('Test successful: {}'.format(expected_path))
+                    result = TestPathResult.SUCCESS
+                else:
+                    logging.error('Expected and actual path differ')
+                    logging.error('Expected: {}'.format(expected_path))
+                    logging.error('Actual:   {}'.format(extracted_path))
+                    result = TestPathResult.TEST_FAILED
+                    assert False
+            else:
+                result = TestPathResult.PACKET_SHORTER_THAN_MIN
+                logging.warning('Packet not sent (%d bytes is shorter than'
+                                ' minimum %d supported)' %
+                                (len(payload),
+                                 Config().get_min_packet_len_generated()))
+        else:
+            logging.info(
+                'Unable to find packet for path: {}'.format(expected_path))
+            result = TestPathResult.NO_PACKET_FOUND
+
+        if packet_hexstr is None:
+            input_packets = []
+        else:
+            input_metadata = {
+                '.'.join(var_name):
+                    model.eval(value, model_completion=True).as_long()
+                for (var_name, value) in context.input_metadata.iteritems()
+            }
+            input_packets = [
+                OrderedDict([
+                    # TBD: Currently we always send packets into port 0.
+                    # Should generalize that later.
+                    ("port", 0),
+                    ("packet_len_bytes", packet_len_bytes),
+                    ("packet_hexstr", packet_hexstr),
+                    ("input_metadata", input_metadata),
+                ])
+            ]
+
+        # TBD: Would be nice to get rid of u in front of strings on
+        # paths, e.g. u'node_2', u'p4_programs/demo1b.p4'.  Maybe it
+        # is beneficial to leave those in there for some reason, but I
+        # suspect a change in representation of parser paths and/or
+        # control paths could make bigger changes there such that we
+        # want to wait until those changes are made before mucking
+        # around with how they are returned.
+
+        # Instead of calling str() on every element of a path, might
+        # be nicer to convert them to a type that can be more easily
+        # represented as separate parts in JSON, e.g. nested lists or
+        # dicts of strings, numbers, booleans.
+        test_case = OrderedDict([
+            ("log_file_id", count),
+            ("result", result.name),
+            ("expected_path", map(str, expected_path)),
+            ("complete_path", is_complete_control_path),
+            ("ss_cli_setup_cmds", ss_cli_setup_cmds),
+            ("input_packets", input_packets),
+            # ("expected_output_packets", TBD),
+            ("parser_path_len", len(parser_path)),
+            ("ingress_path_len", len(control_path)),
+        ])
+        if uninitialized_read_data:
+            test_case["uninitialized_read_data"] = uninitialized_read_data
+        if invalid_header_write_data:
+            test_case["invalid_header_write_data"] = invalid_header_write_data
+        if actual_path_data:
+            test_case["actual_path"] = map(str, actual_path_data)
+
+        # Put details like these later in OrderedDict test_case,
+        # especialy long ones.  This makes the shorter and/or more
+        # essential information like that above come first, and
+        # together.
+
+        # Should be filled in by calling function, order will be maintained.
+        test_case["time_sec_generate_ingress_constraints"] = None
+        test_case["time_sec_solve"] = None
+        test_case["time_sec_simulate_packet"] = None
+
+        test_case["parser_path"] = map(str, parser_path)
+        test_case["ingress_path"] = map(str, control_path)
+        test_case["table_setup_cmd_data"] = table_setup_cmd_data
+
+        payloads = []
+        if payload:
+            payloads.append(payload)
+
+        return result, test_case, payloads
+
+    def test_packet(self, packet, table_configs, source_info_to_node_name):
+        """This function starts simple_switch, sends a packet to the switch and
+        returns the parser states that the packet traverses based on the output of
+        simple_switch."""
+
+        with SimpleSwitch(self.json_file) as switch:
+            for table, action, values, _, params, priority in table_configs:
+                # XXX: inelegant
+                const_table = self.pipeline.tables[table].has_const_entries()
+
+                # Extract values of parameters, without the names
+                param_vals = map(lambda x: x[1], params)
+                if len(values) == 0 or const_table or action.default_entry:
+                    switch.table_set_default(table, action.get_name(),
+                                             param_vals)
+                else:
+                    switch.table_add(table, action.get_name(), values,
+                                     param_vals, priority)
+
+            extracted_path = switch.send_and_check_only_1_packet(
+                packet, source_info_to_node_name)
+
+            switch.clear_tables()
+
+        return extracted_path

--- a/src/p4pktgen/core/test_cases.py
+++ b/src/p4pktgen/core/test_cases.py
@@ -16,6 +16,15 @@ TestPathResult = Enum(
 )
 
 
+def record_test_case(result, is_complete_control_path):
+    if result in [TestPathResult.UNINITIALIZED_READ,
+                  TestPathResult.INVALID_HEADER_WRITE]:
+        return True
+    if result == TestPathResult.SUCCESS and is_complete_control_path:
+        return True
+    return False
+
+
 # TBD: There is probably a better way to convert the params from
 # whatever type they are coming from the SMT solver, to something that
 # can be written out as JSON.  This seems to work, though.

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -1,32 +1,12 @@
-# TODO:
-#
-# - Position is a 32-bit integer right now. Smaller/larger?
-# - Move to smt-switch
-
-import copy
 import logging
-import math
-import pprint as pp
-import time
 
-from enum import Enum
 from z3 import *
 
 from p4pktgen.config import Config
-from p4pktgen.core.context import Context
-from p4pktgen.core.packet import Packet
 from p4pktgen.hlir.transition import *
 from p4pktgen.hlir.type_value import *
 from p4pktgen.p4_hlir import *
-from p4pktgen.switch.simple_switch import SimpleSwitch
 from p4pktgen.util.bitvec import equalize_bv_size
-from p4pktgen.util.statistics import Statistics, Timer
-from p4pktgen.util.table import Table
-
-TestPathResult = Enum(
-    'TestPathResult',
-    'SUCCESS NO_PACKET_FOUND TEST_FAILED UNINITIALIZED_READ INVALID_HEADER_WRITE PACKET_SHORTER_THAN_MIN'
-)
 
 
 def min_bits_for_uint(uint):
@@ -40,7 +20,7 @@ def min_bits_for_uint(uint):
     # This expression returns correct values up to somewhere near ((1
     # << 48) - 1), but somewhere around that magnitude of integer it
     # returns values that are too large by 1.
-    #return int(math.log(uint, 2)) + 1
+    # return int(math.log(uint, 2)) + 1
 
     min_width = 1
     cur_width = 32
@@ -66,72 +46,16 @@ def min_bits_for_uint(uint):
     return cur_width
 
 
-# TBD: There is probably a better way to convert the params from
-# whatever type they are coming from the SMT solver, to something that
-# can be written out as JSON.  This seems to work, though.
-def model_value_to_long(model_val):
-    try:
-        return long(str(model_val))
-    except ValueError:
-        # This can happen when trying to convert values that are
-        # actually still variables in the model.  For example, when a
-        # key in a table is used that way, without first being
-        # initialized.
-        return None
+class Translator(object):
+    """Translates p4pktgen path objects into z3 representations.  Should have a
+    fixed state after instantiation with the HLIR and pipeline it's translating
+    for."""
 
-
-def source_info_to_dict(source_info):
-    if source_info is None:
-        return None
-    return OrderedDict(
-        [('filename', source_info.filename), ('line', source_info.line),
-         ('column', source_info.column), ('source_fragment',
-                                          source_info.source_fragment)])
-
-
-class Translator:
-    def __init__(self, json_file, hlir, pipeline):
-        if Config().get_run_simple_switch():
-            self.json_file = json_file
-        else:
-            self.json_file = None
-
-        self.solver = SolverFor('QF_UFBV')
-        self.solver.push()
-        self.solver_result = None
+    def __init__(self, hlir, pipeline):
+        # These are used for necessary lookups and should be unchanged by any
+        # operation on instances of this class.
         self.hlir = hlir
         self.pipeline = pipeline
-        self.context_history = [Context()]  # XXX: implement better mechanism
-        self.result_history = [[]]
-        self.context_history_lens = []
-        self.total_switch_time = 0.0
-
-        self.constraints = None if Config().get_incremental() else [[]]
-
-    def current_context(self):
-        return self.context_history[-1]
-
-    def push(self):
-        self.solver.push()
-        self.context_history_lens.append(len(self.context_history))
-        self.result_history.append([])
-
-        if self.constraints is not None:
-            self.constraints.append([])
-
-    def pop(self):
-        if Config().get_incremental():
-            self.solver.pop()
-
-        old_len = self.context_history_lens.pop()
-        self.context_history = self.context_history[:old_len]
-        self.result_history.pop()
-
-        if self.constraints is not None:
-            self.constraints.pop()
-
-    def cleanup(self):
-        pass
 
     def p4_value_to_bv(self, value, size):
         # XXX: Support values that are not simple hexstrs
@@ -316,7 +240,7 @@ class Translator:
                     BitVecVal(field.size, 32)
                     for _, field in header_type.fields.items()
                 ])
-                self.sym_packet.set_max_length(
+                sym_packet.set_max_length(
                     simplify(new_pos + extract_offset - 8))
                 return new_pos
 
@@ -383,7 +307,7 @@ class Translator:
                         else:
                             header_size += BitVecVal(field.size, 32)
 
-                self.sym_packet.set_max_length(
+                sym_packet.set_max_length(
                     simplify(new_pos + header_size - 8))
                 return new_pos
             elif fail == 'HeaderTooShort':
@@ -622,18 +546,6 @@ class Translator:
 
         context.remove_runtime_data()
 
-    def table_set_default_cmd_string(self, table, action, params):
-        return ('{} {} {}'.format(table, action,
-                                  ' '.join([str(x) for x in params])))
-
-    def table_add_cmd_string(self, table, action, values, params, priority):
-        priority_str = ""
-        if priority:
-            priority_str = " %d" % (priority)
-        return ('{} {} {} => {}{}'.format(table, action, ' '.join(values),
-                                          ' '.join([str(x) for x in params]),
-                                          priority_str))
-
     def parser_transition_key_constraint(self, sym_transition_keys, value,
                                          mask):
         # value should be int or long
@@ -671,179 +583,10 @@ class Translator:
             constraint = (bitvecs[0] & bv_mask) == (bv_value & bv_mask)
         return constraint
 
-    def init_context(self):
-        assert len(self.context_history) == 1
-        assert len(self.result_history) == 1
-
-        context = Context()
-
-        # Register the fields of all headers in the context
-        for header_name, header in self.hlir.headers.items():
-            for field_name, field in header.fields.items():
-                if field_name == '$valid$':
-                    # All valid bits in headers are 0 in the beginning
-                    context.insert(field, BitVecVal(0, 1))
-                else:
-                    context.register_field(field)
-
-        for stack_name, stack in self.hlir.header_stacks.items():
-            for i in range(stack.size):
-                context.set_field_value('{}[{}]'.format(stack_name, i),
-                                        '$valid$', BitVecVal(0, 1))
-
-        # XXX: refactor
-        context.set_field_value('standard_metadata', 'ingress_port',
-                                BitVec('$ingress_port$', 9))
-        context.set_field_value('standard_metadata', 'packet_length',
-                                self.sym_packet.get_sym_packet_size())
-        context.set_field_value('standard_metadata', 'instance_type',
-                                BitVec('$instance_type$', 32))
-        context.set_field_value('standard_metadata', 'egress_spec',
-                                BitVecVal(0, 9))
-
-        self.context_history[0] = context
-        self.result_history[0] = []
-
-    def generate_parser_constraints(self, parser_path):
-        parser_constraints_gen_timer = Timer('parser_constraints_gen')
-        parser_constraints_gen_timer.start()
-
-        if Config().get_incremental():
-            self.solver.pop()
-            self.solver.push()
-
-        self.sym_packet = Packet()
-        self.init_context()
-        constraints = []
-
-        # XXX: make this work for multiple parsers
-        parser = self.hlir.parsers['parser']
-        pos = BitVecVal(0, 32)
-        logging.info('path = {}'.format(' -> '.join(
-            [str(n) for n in list(parser_path)])))
-        for path_transition in parser_path:
-            assert isinstance(path_transition, ParserTransition) or isinstance(
-                path_transition, ParserOpTransition)
-
-            node = path_transition.src
-            next_node = path_transition.dst
-            logging.debug('{} -> {}\tpos = {}'.format(node, next_node, pos))
-            new_pos = pos
-            parse_state = parser.parse_states[node]
-
-            skip_select = False
-            for op_idx, parser_op in enumerate(parse_state.parser_ops):
-                fail = ''
-                if isinstance(
-                        path_transition, ParserOpTransition
-                ) and op_idx == path_transition.op_idx and path_transition.next_state == 'sink':
-                    fail = path_transition.error_str
-                    skip_select = True
-
-                new_pos = self.parser_op_to_smt(
-                    self.current_context(), self.sym_packet, parser_op, fail,
-                    pos, new_pos, constraints)
-
-                if skip_select:
-                    break
-
-            if next_node == P4_HLIR.PACKET_TOO_SHORT:
-                # Packet needs to be at least one byte too short
-                self.sym_packet.set_max_length(simplify(new_pos - 8))
-                break
-
-            if not skip_select:
-                sym_transition_key = []
-                for transition_key_elem in parse_state.transition_key:
-                    if isinstance(transition_key_elem, TypeValueField):
-                        sym_transition_key.append(self.current_context(
-                        ).get_header_field(transition_key_elem.header_name,
-                                           transition_key_elem.header_field))
-                    elif isinstance(transition_key_elem, TypeValueStackField):
-                        sym_transition_key.append(
-                            self.current_context().get_last_header_field(
-                                transition_key_elem.header_name,
-                                transition_key_elem.header_field,
-                                self.hlir.get_header_stack(
-                                    transition_key_elem.header_name).size))
-                    else:
-                        raise Exception(
-                            'Transition key type not supported: {}'.format(
-                                transition_key_elem.__class__))
-
-                # XXX: is this check really necessary?
-                if len(sym_transition_key) > 0:
-                    # Make sure that we are not hitting any of the cases before the
-                    # case that we care about
-                    other_constraints = []
-                    for current_transition in parse_state.transitions:
-                        if current_transition != path_transition:
-                            other_constraints.append(
-                                self.parser_transition_key_constraint(
-                                    sym_transition_key, current_transition.
-                                    value, current_transition.mask))
-                        else:
-                            break
-
-                    constraints.append(Not(Or(other_constraints)))
-                    logging.debug(
-                        "Other constraints: {}".format(other_constraints))
-
-                    # The constraint for the case that we are interested in
-                    if path_transition.value is not None:
-                        constraint = self.parser_transition_key_constraint(
-                            sym_transition_key, path_transition.value,
-                            path_transition.mask)
-                        constraints.append(constraint)
-
-                logging.debug(sym_transition_key)
-                pos = simplify(new_pos)
-
-        # XXX: workaround
-        self.current_context().set_field_value('meta_meta', 'packet_len',
-                                               self.sym_packet.packet_size_var)
-        constraints.extend(self.sym_packet.get_packet_constraints())
-        constraints.extend(self.current_context().get_name_constraints())
-        self.solver.add(And(constraints))
-
-        parser_constraints_gen_timer.stop()
-        logging.info('Generate parser constraints: %.3f sec' %
-                     (parser_constraints_gen_timer.get_time()))
-
-        Statistics().solver_time.start()
-        result = self.solver.check()
-        Statistics().num_solver_calls += 1
-        Statistics().solver_time.stop()
-
-        if not Config().get_incremental():
-            self.constraints[0] = constraints
-            self.solver.reset()
-
-        return result == sat
-
     def parser_op_trans_to_str(self, op_trans):
         # XXX: after unifying type value representations
         # assert isinstance(op_trans.op.value[1], TypeValueHexstr)
         return op_trans.error_str
-
-    def log_model(self, model, context_history):
-        var_vals = defaultdict(lambda: [])
-        for i, context in enumerate(context_history):
-            for var, smt_var in context.var_to_smt_var.items():
-                if len(var_vals[var]) < i:
-                    # Add empty entries for the contexts where the variable
-                    # didn't exist
-                    var_vals[var] += [''] * (i - len(var_vals[var]))
-
-                if smt_var is None:
-                    var_vals[var].append('')
-                else:
-                    var_vals[var].append(str(model.eval(smt_var)))
-
-        table = Table()
-        table.add_rows([['.'.join(var)] + vals
-                        for var, vals in sorted(var_vals.items())])
-        logging.info('Model\n' + str(table))
 
     def control_transition_constraints(self, context, transition):
         assert isinstance(transition, Edge)
@@ -904,408 +647,3 @@ class Translator:
             self.parser_op_trans_to_str(n) for n in parser_path
         ] + ['sink'] + [(n.src, n) for n in control_path]
         return expected_path
-
-    def add_path_constraints(self, control_path):
-        assert len(control_path) == len(self.context_history_lens) \
-               or not Config().get_incremental()
-        self.context_history.append(copy.copy(self.current_context()))
-        context = self.current_context()
-        constraints = []
-
-        # XXX: very ugly to split parsing/control like that, need better solution
-        logging.info('control_path = {}'.format(control_path))
-
-        if len(control_path) > 0:
-            transition = control_path[-1]
-            constraints.extend(
-                self.control_transition_constraints(context, transition))
-            self.context_history.append(copy.copy(self.current_context()))
-            context = self.current_context()
-
-        constraints.extend(context.get_name_constraints())
-        # XXX: Workaround for simple_switch issue
-        constraints.append(
-            Or(
-                ULT(context.get_header_field('standard_metadata', 'egress_spec'), 256),
-                context.get_header_field('standard_metadata', 'egress_spec') == 511
-            )
-        )
-
-        if not Config().get_incremental():
-            for cs in self.constraints:
-                self.solver.add(And(cs))
-            self.constraints[-1].extend(constraints)
-
-        # Construct and test the packet
-        # logging.debug(And(constraints))
-        self.solver.add(And(constraints))
-        self.solver_result = None
-
-    def try_quick_solve(self, control_path, is_complete_control_path):
-        context = self.current_context()
-        # If the last part of the path is a table with no const entries
-        # and the prefix of the current path is satisfiable, so is the new
-        # path
-        result = None
-        if len(control_path) > 0 \
-                and not is_complete_control_path \
-                and len(context.uninitialized_reads) == 0 \
-                and len(context.invalid_header_writes) == 0:
-            transition = control_path[-1]
-            if Config().get_table_opt() \
-                    and transition.transition_type == TransitionType.ACTION_TRANSITION:
-                assert transition.src in self.pipeline.tables
-                table = self.pipeline.tables[transition.src]
-                assert not table.has_const_entries()
-                result = TestPathResult.SUCCESS
-                self.result_history[-2].append(result)
-            elif Config().get_conditional_opt() \
-                    and transition.transition_type == TransitionType.BOOL_TRANSITION:
-                cond_history = self.result_history[-2]
-                if len(cond_history) > 0 \
-                        and cond_history[0] == TestPathResult.NO_PACKET_FOUND:
-                    assert len(cond_history) == 1
-                    result = TestPathResult.SUCCESS
-                    self.result_history[-2].append(result)
-        return result
-
-    def solve_path(self):
-        Statistics().solver_time.start()
-        self.solver_result = self.solver.check()
-        Statistics().num_solver_calls += 1
-        Statistics().solver_time.stop()
-        return self.solver_result
-
-    def generate_test_case(self, expected_path,
-                           parser_path, control_path, is_complete_control_path,
-                           source_info_to_node_name, count):
-        packet_hexstr = None
-        payload = None
-        ss_cli_setup_cmds = []
-        table_setup_cmd_data = []
-        uninitialized_read_data = None
-        invalid_header_write_data = None
-        actual_path_data = None
-        result = None
-
-        context = self.current_context()
-        start_time = time.time()
-        if self.solver_result != unsat:
-            model = self.solver.model()
-            if not Config().get_silent():
-                self.log_model(model, self.context_history)
-            payload = self.sym_packet.get_payload_from_model(model)
-
-            # Determine table configurations
-            table_configs = []
-            for t in control_path:
-                table_name = t.src
-                transition = t
-                if table_name in self.pipeline.tables \
-                        and context.has_table_values(table_name):
-                    runtime_data_values = []
-                    for i, runtime_param in enumerate(
-                            transition.action.runtime_data):
-                        runtime_data_values.append(
-                            (runtime_param.name,
-                             model[context.get_runtime_data_for_table_action(
-                                 table_name, transition.action.name,
-                                 runtime_param.name, i)]))
-                    sym_table_values = context.get_table_values(
-                        model, table_name)
-
-                    table = self.pipeline.tables[table_name]
-                    table_values_strs = []
-                    table_key_data = []
-                    table_entry_priority = None
-                    for table_key, sym_table_value in zip(
-                            table.key, sym_table_values):
-                        key_field_name = '.'.join(table_key.target)
-                        sym_table_value_long = model_value_to_long(
-                            sym_table_value)
-                        if table_key.match_type == 'lpm':
-                            bitwidth = context.get_header_field_size(
-                                table_key.target[0], table_key.target[1])
-                            table_values_strs.append(
-                                '{}/{}'.format(sym_table_value, bitwidth))
-                            table_key_data.append(
-                                OrderedDict([
-                                    ('match_kind', 'lpm'),
-                                    ('key_field_name', key_field_name),
-                                    ('value', sym_table_value_long),
-                                    ('prefix_length', bitwidth),
-                                ]))
-                        elif table_key.match_type == 'ternary':
-                            # Always use exact match mask, which is
-                            # represented in simple_switch_CLI as a 1 bit
-                            # in every bit position of the field.
-                            bitwidth = context.get_header_field_size(
-                                table_key.target[0], table_key.target[1])
-                            mask = (1 << bitwidth) - 1
-                            table_values_strs.append(
-                                '{}&&&{}'.format(sym_table_value, mask))
-                            table_entry_priority = 1
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'ternary'), (
-                                    'key_field_name', key_field_name), (
-                                        'value', sym_table_value_long), (
-                                            'mask', mask)]))
-                        elif table_key.match_type == 'range':
-                            # Always use a range where the min and max
-                            # values are exactly the one desired value
-                            # generated.
-                            table_values_strs.append('{}->{}'.format(
-                                sym_table_value, sym_table_value))
-                            table_entry_priority = 1
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'range'), (
-                                    'key_field_name', key_field_name
-                                ), ('min_value', sym_table_value_long), (
-                                    'max_value', sym_table_value_long)]))
-                        elif table_key.match_type == 'exact':
-                            table_values_strs.append(str(sym_table_value))
-                            table_key_data.append(
-                                OrderedDict([('match_kind', 'exact'), (
-                                    'key_field_name', key_field_name), (
-                                        'value', sym_table_value_long)]))
-                        else:
-                            raise Exception('Match type {} not supported'.
-                                            format(table_key.match_type))
-
-                    logging.debug("table_name %s"
-                                  " table.default_entry.action_const %s" %
-                                  (table_name,
-                                   table.default_entry.action_const))
-                    if (len(table_values_strs) == 0
-                            and table.default_entry.action_const):
-                        # Then we cannot change the default action for the
-                        # table at run time, so don't remember any entry
-                        # for this table.
-                        pass
-                    else:
-                        table_configs.append(
-                            (table_name, transition, table_values_strs,
-                             table_key_data, runtime_data_values,
-                             table_entry_priority))
-
-            # Print table configuration
-            for table, action, values, key_data, params, priority in table_configs:
-                # XXX: inelegant
-                const_table = self.pipeline.tables[table].has_const_entries()
-
-                params2 = []
-                param_vals = []
-                for param_name, param_val in params:
-                    param_val = model_value_to_long(param_val)
-                    param_vals.append(param_val)
-                    params2.append(
-                        OrderedDict([('name', param_name), ('value', param_val)
-                                     ]))
-                if len(values) == 0 or const_table or action.default_entry:
-                    ss_cli_cmd = ('table_set_default ' +
-                                  self.table_set_default_cmd_string(
-                                      table, action.get_name(), param_vals))
-                    logging.info(ss_cli_cmd)
-                    table_setup_info = OrderedDict(
-                        [("command", "table_set_default"), ("table_name",
-                                                            table),
-                         ("action_name",
-                          action.get_name()), ("action_parameters", params2)])
-                else:
-                    ss_cli_cmd = ('table_add ' + self.table_add_cmd_string(
-                        table, action.get_name(), values, param_vals,
-                        priority))
-                    table_setup_info = OrderedDict(
-                        [("command", "table_add"), ("table_name",
-                                                    table), ("keys", key_data),
-                         ("action_name",
-                          action.get_name()), ("action_parameters", params2)])
-                    if priority is not None:
-                        table_setup_info['priority'] = priority
-                logging.info(ss_cli_cmd)
-                ss_cli_setup_cmds.append(ss_cli_cmd)
-                table_setup_cmd_data.append(table_setup_info)
-            packet_len_bytes = len(payload)
-            packet_hexstr = ''.join([('%02x' % (x)) for x in payload])
-            logging.info("packet (%d bytes) %s"
-                         "" % (packet_len_bytes, packet_hexstr))
-
-            if len(context.uninitialized_reads) != 0:
-                result = TestPathResult.UNINITIALIZED_READ
-                uninitialized_read_data = []
-                for uninitialized_read in context.uninitialized_reads:
-                    var_name, source_info = uninitialized_read
-                    logging.error('Uninitialized read of {} at {}'.format(
-                        var_name, source_info))
-                    uninitialized_read_data.append(
-                        OrderedDict([("variable_name", var_name), (
-                            "source_info", source_info_to_dict(source_info))]))
-            elif len(context.invalid_header_writes) != 0:
-                result = TestPathResult.INVALID_HEADER_WRITE
-                invalid_header_write_data = []
-                for invalid_header_write in context.invalid_header_writes:
-                    var_name, source_info = invalid_header_write
-                    logging.error('Invalid header write of {} at {}'.format(
-                        var_name, source_info))
-                    invalid_header_write_data.append(
-                        OrderedDict([("variable_name", var_name), (
-                            "source_info", source_info_to_dict(source_info))]))
-            elif len(payload) >= Config().get_min_packet_len_generated():
-                if Config().get_run_simple_switch() \
-                        and is_complete_control_path:
-                    extracted_path = self.test_packet(payload, table_configs,
-                                                      source_info_to_node_name)
-
-                    if is_complete_control_path:
-                        match = (expected_path == extracted_path)
-                    else:
-                        len1 = len(expected_path)
-                        len2 = len(extracted_path)
-                        match = (expected_path == extracted_path[0:len1]
-                                 ) and len1 <= len2
-                else:
-                    match = True
-                if match:
-                    logging.info('Test successful: {}'.format(expected_path))
-                    result = TestPathResult.SUCCESS
-                else:
-                    logging.error('Expected and actual path differ')
-                    logging.error('Expected: {}'.format(expected_path))
-                    logging.error('Actual:   {}'.format(extracted_path))
-                    result = TestPathResult.TEST_FAILED
-                    assert False
-            else:
-                result = TestPathResult.PACKET_SHORTER_THAN_MIN
-                logging.warning('Packet not sent (%d bytes is shorter than'
-                                ' minimum %d supported)' %
-                                (len(payload),
-                                 Config().get_min_packet_len_generated()))
-        else:
-            logging.info(
-                'Unable to find packet for path: {}'.format(expected_path))
-            result = TestPathResult.NO_PACKET_FOUND
-
-        self.total_switch_time += time.time() - start_time
-
-        if packet_hexstr is None:
-            input_packets = []
-        else:
-            input_metadata = {
-                '.'.join(var_name):
-                    model.eval(value, model_completion=True).as_long()
-                for (var_name, value) in context.input_metadata.iteritems()
-            }
-            input_packets = [
-                OrderedDict([
-                    # TBD: Currently we always send packets into port 0.
-                    # Should generalize that later.
-                    ("port", 0),
-                    ("packet_len_bytes", packet_len_bytes),
-                    ("packet_hexstr", packet_hexstr),
-                    ("input_metadata", input_metadata),
-                ])
-            ]
-
-        # TBD: Would be nice to get rid of u in front of strings on
-        # paths, e.g. u'node_2', u'p4_programs/demo1b.p4'.  Maybe it
-        # is beneficial to leave those in there for some reason, but I
-        # suspect a change in representation of parser paths and/or
-        # control paths could make bigger changes there such that we
-        # want to wait until those changes are made before mucking
-        # around with how they are returned.
-
-        # Instead of calling str() on every element of a path, might
-        # be nicer to convert them to a type that can be more easily
-        # represented as separate parts in JSON, e.g. nested lists or
-        # dicts of strings, numbers, booleans.
-        test_case = OrderedDict([
-            ("log_file_id", count),
-            ("result", result.name),
-            ("expected_path", map(str, expected_path)),
-            ("complete_path", is_complete_control_path),
-            ("ss_cli_setup_cmds", ss_cli_setup_cmds),
-            ("input_packets", input_packets),
-            #("expected_output_packets", TBD),
-            ("parser_path_len", len(parser_path)),
-            ("ingress_path_len", len(control_path)),
-        ])
-        if uninitialized_read_data:
-            test_case["uninitialized_read_data"] = uninitialized_read_data
-        if invalid_header_write_data:
-            test_case["invalid_header_write_data"] = invalid_header_write_data
-        if actual_path_data:
-            test_case["actual_path"] = map(str, actual_path_data)
-
-        # Put details like these later in OrderedDict test_case,
-        # especialy long ones.  This makes the shorter and/or more
-        # essential information like that above come first, and
-        # together.
-
-        # Should be filled in by calling function, order will be maintained.
-        test_case["time_sec_generate_ingress_constraints"] = None
-        test_case["time_sec_solve"] = None
-        test_case["time_sec_simulate_packet"] = None
-
-        test_case["parser_path"] = map(str, parser_path)
-        test_case["ingress_path"] = map(str, control_path)
-        test_case["table_setup_cmd_data"] = table_setup_cmd_data
-
-        payloads = []
-        if payload:
-            payloads.append(payload)
-
-        self.result_history[-2].append(result)
-        return (result, test_case, payloads)
-
-    def constrain_last_extract_vl_lengths(self, condition):
-        """This function adds constraints to the solver preventing it from
-         selecting the same lengths for extract_vl operations that were selected
-         in the last solution.  Returns whether any constraints were added."""
-
-        # Should be called after a solve attempt, should not be called if it
-        # failed.
-        assert self.solver_result is not None and self.solver_result != unsat
-
-        context = self.current_context()
-        if not context.parsed_vl_extracts or condition is None:
-            return False
-
-        model = self.solver.model()
-        solution_sizes = []
-        for var, sym_size in context.parsed_vl_extracts.items():
-            solved_size = model[sym_size]
-            solution_sizes.append(sym_size == solved_size)
-
-        if condition == 'and':
-            self.solver.add(Not(And(solution_sizes)))
-        else:
-            assert condition == 'or'
-            self.solver.add(Not(Or(solution_sizes)))
-
-        return True
-
-    def test_packet(self, packet, table_configs, source_info_to_node_name):
-        """This function starts simple_switch, sends a packet to the switch and
-        returns the parser states that the packet traverses based on the output of
-        simple_switch."""
-
-        with SimpleSwitch(self.json_file) as switch:
-            for table, action, values, _, params, priority in table_configs:
-                # XXX: inelegant
-                const_table = self.pipeline.tables[table].has_const_entries()
-
-                # Extract values of parameters, without the names
-                param_vals = map(lambda x: x[1], params)
-                if len(values) == 0 or const_table or action.default_entry:
-                    switch.table_set_default(table, action.get_name(),
-                                                  param_vals)
-                else:
-                    switch.table_add(table, action.get_name(), values,
-                                          param_vals, priority)
-
-            extracted_path = switch.send_and_check_only_1_packet(
-                packet, source_info_to_node_name)
-
-            switch.clear_tables()
-
-        return extracted_path

--- a/src/p4pktgen/switch/simple_switch.py
+++ b/src/p4pktgen/switch/simple_switch.py
@@ -321,19 +321,17 @@ class SimpleSwitch:
         logging.debug("Calling fp.flush() after _writer_header(None)")
         self.intf_info[intf_num]['pcap_in_fp'] = fp
 
-    def table_add(self, table, action, values, params, priority):
-        self.modified_tables.append(table)
-        priority_str = ""
-        if priority:
-            priority_str = " %d" % (priority)
-        self.api.do_table_add(
-            '{} {} {} => {}{}'.format(table, action, ' '.join(
-                values), ' '.join([str(x) for x in params]), priority_str))
-
-    def table_set_default(self, table, action, params):
-        self.modified_tables.append(table)
-        self.api.do_table_set_default('{} {} {}'.format(
-            table, action, ' '.join([str(x) for x in params])))
+    def table_cmd(self, cmd):
+        clis = {'default': 'table_set_default ',
+                'add': 'table_add '}
+        if cmd.startswith(clis['default']):
+            body = cmd[len(clis['default']):]
+            self.api.do_table_set_default(body)
+        elif cmd.startswith(clis['add']):
+            body = cmd[len(clis['add']):]
+            self.api.do_table_add(body)
+        else:
+            raise Exception('Unknown table cmd: %s' % cmd)
 
     def clear_tables(self):
         """Clears all modified tables."""

--- a/src/p4pktgen/util/statistics.py
+++ b/src/p4pktgen/util/statistics.py
@@ -88,7 +88,7 @@ class Statistics:
         self.num_covered_edges = 0
         self.num_done = 0
 
-    def record(self, result, record_path, translator):
+    def record(self, result, record_path, path_solver):
         self.record_count += 1
 
         current_time = time.time()
@@ -101,7 +101,7 @@ class Statistics:
         if self.record_count % 100 == 0:
             self.breakdown_file.write('{},{},{},{},{},{}\n'.format(
                 current_time - self.start_time,
-                self.num_solver_calls, translator.total_switch_time,
+                self.num_solver_calls, path_solver.total_switch_time,
                 Statistics().solver_time,
                 self.avg_full_path_len.get_avg(),
                 self.avg_unsat_path_len.get_avg(),

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -3,7 +3,7 @@ import pytest
 
 from p4pktgen.main import generate_test_cases, path_tuple
 from p4pktgen.config import Config
-from p4pktgen.core.translator import TestPathResult
+from p4pktgen.core.solver import TestPathResult
 
 
 def load_test_config(no_packet_length_errs=True,

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -3,7 +3,7 @@ import pytest
 
 from p4pktgen.main import generate_test_cases, path_tuple
 from p4pktgen.config import Config
-from p4pktgen.core.solver import TestPathResult
+from p4pktgen.core.test_cases import TestPathResult
 
 
 def load_test_config(no_packet_length_errs=True,

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -62,6 +62,7 @@ def load_test_config(no_packet_length_errs=True,
     config.incremental = True
     config.output_path = './test-case'
     config.extract_vl_variation = None
+    config.consolidate_tables = None
 
 
 def run_test(json_filename):

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -572,3 +572,16 @@ class CheckSystem:
             ('start', 'sink', (u'node_2', (False, (u'narrow-extractions.p4', 42, u'h.narrow.n0 == 1 && h.narrow.n1 == 1 && h.narrow.n2 == 1 && ...'))), (u'node_4', (False, (u'narrow-extractions.p4', 46, u'h.narrow.n4 == 31'))), (u'node_6', (False, (u'narrow-extractions.p4', 49, u'h.narrow.n6 == 7')))): TestPathResult.SUCCESS,
         }
         assert results == expected_results
+
+
+    @pytest.mark.xfail(reason="Table const default actions cause simple_switch to raise error.")
+    def check_simple_table_with_const_default_action(self):
+        # This test checks that a simple program with a table that has a const
+        # default action can be tested with the simple switch.
+        load_test_config(run_simple_switch=True)
+        results = run_test('examples/simple-table.json')
+        expected_results = {
+            ('start', 'sink', (u'ingress.table1', u'ingress.setx')): TestPathResult.SUCCESS,
+            ('start', 'sink', (u'ingress.table1', u'ingress.noop')): TestPathResult.SUCCESS,
+        }
+        assert results == expected_results


### PR DESCRIPTION
Adds an option to consolidate paths around common table configs.  The result is that many (potentially all) test cases produced for a program will have identical table configs.
This is done on a best effort basis, it is not guaranteed to find the maximum number of paths that can be grouped.