### PR TITLE
for-upstream/randomization

### DIFF
--- a/examples/randomization-test.json
+++ b/examples/randomization-test.json
@@ -1,0 +1,364 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["userMetadata.meta_byte", 8, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "abyte",
+      "id" : 2,
+      "fields" : [
+        ["data", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr_byte",
+      "id" : 2,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr_byte"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "randomization-test.p4",
+        "line" : 32,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "ingress.noop",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : []
+    },
+    {
+      "name" : "ingress.set_hdr_byte",
+      "id" : 1,
+      "runtime_data" : [
+        {
+          "name" : "val",
+          "bitwidth" : 2
+        }
+      ],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr_byte", "data"]
+            },
+            {
+              "type" : "expression",
+              "value" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "&",
+                  "left" : {
+                    "type" : "local",
+                    "value" : 0
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0xff"
+                  }
+                }
+              }
+            }
+          ],
+          "source_info" : {
+            "filename" : "randomization-test.p4",
+            "line" : 38,
+            "column" : 8,
+            "source_fragment" : "h.hdr_byte.data = (bit<8>) val"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "randomization-test.p4",
+        "line" : 33,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "ingress.table1",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "randomization-test.p4",
+            "line" : 41,
+            "column" : 10,
+            "source_fragment" : "table1"
+          },
+          "key" : [
+            {
+              "match_type" : "exact",
+              "name" : "h.hdr_byte.data",
+              "target" : ["hdr_byte", "data"],
+              "mask" : null
+            }
+          ],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0, 1],
+          "actions" : ["ingress.noop", "ingress.set_hdr_byte"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "ingress.noop" : null,
+            "ingress.set_hdr_byte" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "randomization-test.p4",
+            "line" : 51,
+            "column" : 12,
+            "source_fragment" : "h.hdr_byte.data & 0xbb == 0xbb && m.meta_byte & 0x77 == 0x77"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "and",
+              "left" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "==",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["hdr_byte", "data"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xbb"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0xbb"
+                  }
+                }
+              },
+              "right" : {
+                "type" : "expression",
+                "value" : {
+                  "op" : "==",
+                  "left" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["scalars", "userMetadata.meta_byte"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0x77"
+                      }
+                    }
+                  },
+                  "right" : {
+                    "type" : "hexstr",
+                    "value" : "0x77"
+                  }
+                }
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "ingress.table1"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "randomization-test.p4",
+        "line" : 30,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./randomization-test.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/randomization-test.p4
+++ b/examples/randomization-test.p4
@@ -1,0 +1,60 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test contrives 4 possible values for packet payload, a metadata field
+ * and a table action param on the path that transitions set_hdr_byte.  The test
+ * is used to check whether these values are being selected sufficiently
+ * randomly. */
+
+header abyte {
+    bit<8> data;
+}
+struct Header_t {
+    abyte hdr_byte;
+}
+struct Meta_t {
+    bit<8> meta_byte;
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr_byte);
+        transition accept;
+    }
+}
+
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    action noop() { }
+    /* There are four possible values for val. */
+    action set_hdr_byte(bit<2> val) {
+        h.hdr_byte.data = (bit<8>) val;
+    }
+
+    table table1 {
+        key = { h.hdr_byte.data: exact; }
+        actions = {
+            noop;
+            set_hdr_byte;
+        }
+        const default_action = noop();
+    }
+
+    apply {
+        if (h.hdr_byte.data & 0xbb == 0xbb && m.meta_byte & 0x77 == 0x77) {
+            /* There are four possible values on this path for each of hdr_byte
+             * and meta_byte. */
+            table1.apply();
+        }
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -31,6 +31,7 @@ class Config:
         self.output_path = './test-case'
         self.extract_vl_variation = args.extract_vl_variation
         self.consolidate_tables = args.consolidate_tables
+        self.randomize = args.randomize
 
     def get_debug(self):
         return self.debug
@@ -112,3 +113,6 @@ class Config:
 
     def get_do_consolidate_tables(self):
         return self.consolidate_tables is not None
+
+    def get_randomize(self):
+        return self.randomize

--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -256,12 +256,15 @@ class TableConsolidatedSolver(ConsolidatedSolver):
                 # per action, therefore if action is the table's default it is
                 # only accessible as the table default action.
                 is_default = (action_name == default_action)
-                key_values = [model[element] for element in sym_key]
+                key_values = [model.eval(element, model_completion=True)
+                              for element in sym_key]
 
                 # TODO: Make this the name of the parameter, rather than the
                 #     mangled SMT variable name, only affects cmd_data (not cmd)
-                param_names_values = [(str(param), model[param])
-                                      for param in sym_params]
+                param_names_values = [
+                    (str(param), model.eval(param, model_completion=True))
+                    for param in sym_params
+                ]
 
                 entry_config = self.test_case_builder.get_table_entry_config(
                     table_name, action_name, is_default,

--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -86,10 +86,10 @@ def path_specific_packet(prefix, packet, var_mapping):
     # Only need packet to call get_payload_from_model so only fill in these
     # fields.
     new_packet.packet_size_var = \
-        path_specific_var(prefix, packet.packet_size_var, var_mapping)
+        path_specific_expr(prefix, packet.packet_size_var, var_mapping)
     new_packet.extract_vars = \
-        [(path_specific_var(prefix, length, var_mapping),
-          path_specific_var(prefix, var, var_mapping))
+        [(path_specific_expr(prefix, length, var_mapping),
+          path_specific_expr(prefix, var, var_mapping))
          for length, var in packet.extract_vars]
 
     return new_packet
@@ -401,9 +401,9 @@ class TableConsolidatedSolver(ConsolidatedSolver):
         assert set(table_names) == set(context.table_runtime_data.keys())
         table_data = {}
         for table_name in table_names:
-            new_key_values = [path_specific_var(prefix, var, var_mapping)
+            new_key_values = [path_specific_expr(prefix, var, var_mapping)
                               for var in context.table_key_values[table_name]]
-            new_runtime_data = [path_specific_var(prefix, var, var_mapping)
+            new_runtime_data = [path_specific_expr(prefix, var, var_mapping)
                                 for var in context.table_runtime_data[table_name]]
             table_data[table_name] = (
                 context.table_action[table_name],
@@ -412,7 +412,7 @@ class TableConsolidatedSolver(ConsolidatedSolver):
             )
 
         input_metadata = {
-            var_name: path_specific_var(prefix, var, var_mapping)
+            var_name: path_specific_expr(prefix, var, var_mapping)
             for var_name, var in context.input_metadata.iteritems()
         }
         path_data = (

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -97,6 +97,9 @@ class Context:
     def insert(self, field, sym_val):
         self.set_field_value(field.header.name, field.name, sym_val)
 
+    def set_field_var(self, header_name, header_field, var):
+        self.var_to_smt_var[(header_name, header_field)] = var
+
     def set_field_value(self, header_name, header_field, sym_val):
         var_name = (header_name, header_field)
         do_write = True

--- a/src/p4pktgen/core/packet.py
+++ b/src/p4pktgen/core/packet.py
@@ -37,18 +37,26 @@ class Packet(object):
         """Return the symbolic packet size."""
         return self.packet_size_var
 
-    def extract(self, start, field_size, read_size=None, lookahead=False):
+    def extract(self, start, field_size, read_size=None, lookahead=False,
+                label=None):
         """Return a new Z3 variable modelling a portion of the packet data."""
         varbit = read_size is not None
         if not varbit:
             read_size = BitVecVal(field_size, 32)
 
         if lookahead:
-            var = BitVec('lookahead{}'.format(len(self.lookaheads)), field_size)
+            name = '$lookahead{}$'.format(len(self.lookaheads))
+        else:
+            name = '$packet{}$'.format(len(self.extract_vars))
+        if label is not None:
+            name = '{}.{}'.format(name, label)
+
+        if lookahead:
+            var = BitVec(name, field_size)
             self.lookaheads.append((simplify(start), len(self.extract_vars),
                                     var))
         else:
-            var = BitVec('packet{}'.format(len(self.extract_vars)), field_size)
+            var = BitVec(name, field_size)
             self.extract_vars.append((read_size, var))
             if varbit:
                 self.vl_extract_vars.append((read_size, var))

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -311,6 +311,21 @@ class PathSolver(object):
         Statistics().solver_time.stop()
         return self.solver_result
 
+    def fix_random_constraints(self):
+        """Fixes values for random displacement variables.  Call this when a
+        complete path has been traversed.
+        """
+        context = self.current_context()
+        constraints = []
+        if self.solver_result == sat:
+            for variables in [self.sym_packet.variables, context.variables]:
+                for constraint in variables.random_displacement_constraints():
+                    constraints.append(constraint)
+                    self.solver.add(constraint)
+            self.solve_path()
+            assert self.solver_result == sat
+        return constraints
+
     def generate_test_case(self, expected_path,
                            parser_path, control_path, is_complete_control_path,
                            source_info_to_node_name):

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -215,7 +215,6 @@ class PathSolver(object):
         self.current_context().set_field_value('meta_meta', 'packet_len',
                                                self.sym_packet.packet_size_var)
         constraints.extend(self.sym_packet.get_packet_constraints())
-        constraints.extend(self.current_context().get_name_constraints())
         self.solver.add(And(constraints))
         self.constraints[0] = constraints
 
@@ -250,7 +249,6 @@ class PathSolver(object):
             self.context_history.append(copy.copy(self.current_context()))
             context = self.current_context()
 
-        constraints.extend(context.get_name_constraints())
         # XXX: Workaround for simple_switch issue
         constraints.append(
             Or(
@@ -353,7 +351,7 @@ class PathSolver(object):
         model = self.solver.model()
         solution_sizes = []
         for var, sym_size in context.parsed_vl_extracts.items():
-            solved_size = model[sym_size]
+            solved_size = model.eval(sym_size, model_completion=True)
             solution_sizes.append(sym_size == solved_size)
 
         if condition == 'and':

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -121,6 +121,14 @@ class PathCoverageGraphVisitor(GraphVisitor):
 
         while True:
             self.path_solver.solve_path()
+
+            # Choose values for randomization variables.
+            random_constraints = []
+            fix_random = is_complete_control_path
+            if fix_random:
+                self.path_solver.push()
+                random_constraints = self.path_solver.fix_random_constraints()
+
             time4 = time.time()
 
             result, test_case, packet_list = self.path_solver.generate_test_case(
@@ -132,6 +140,11 @@ class PathCoverageGraphVisitor(GraphVisitor):
             )
             time5 = time.time()
 
+            # Clear the constraints on the values of the randomization
+            # variables.
+            if fix_random:
+                self.path_solver.pop()
+
             results.append(result)
             # If this result wouldn't be recorded, subsequent ones won't be
             # either, so move on.
@@ -142,7 +155,7 @@ class PathCoverageGraphVisitor(GraphVisitor):
                 # TODO: refactor path_solver to allow extraction of result &
                 # record_test_case without building test case.
                 self.table_solver.add_path(
-                    path_id, self.path_solver.constraints,
+                    path_id, self.path_solver.constraints + [random_constraints],
                     self.path_solver.current_context(),
                     self.path_solver.sym_packet,
                     expected_path, self.parser_path, control_path,

--- a/src/p4pktgen/core/test_cases.py
+++ b/src/p4pktgen/core/test_cases.py
@@ -195,7 +195,8 @@ class TestCaseBuilder(object):
                         transition.action.runtime_data):
                     runtime_data_values.append(
                         (runtime_param.name,
-                         model[context.get_table_runtime_data(table_name, i)]))
+                         model.eval(context.get_table_runtime_data(table_name, i),
+                                    model_completion=True)))
                 table_key_values = context.get_table_key_values(
                     model, table_name)
 

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -245,10 +245,10 @@ class Translator(object):
             # Map bits from packet to context
             extract_offset = BitVecVal(0, 32)
             for field_name, field in header_type.fields.items():
-                context.set_field_var(header_name, field_name,
-                                      sym_packet.extract(
-                                          new_pos + extract_offset,
-                                          field.size))
+                label = '{}.{}'.format(header_name, field_name)
+                extraction = sym_packet.extract(new_pos + extract_offset,
+                                                field.size, label=label)
+                context.set_field_var(header_name, field_name, extraction)
                 extract_offset += BitVecVal(field.size, 32)
 
             return new_pos + extract_offset
@@ -339,9 +339,11 @@ class Translator(object):
             for field_name, field in header_type.fields.items():
                 # XXX: deal with valid flags
                 if field_name != '$valid$':
+                    label = '{}.{}'.format(header_name, field_name)
                     if field.var_length:
                         field_val = sym_packet.extract(new_pos + extract_offset,
-                                                       field.size, sym_size)
+                                                       field.size, sym_size,
+                                                       label=label)
                         field_size_c = BitVecVal(field.size, sym_size.size())
                         constraints.append(ULE(sym_size, field_size_c))
                         context.record_extract_vl(header_name, field_name, sym_size)
@@ -352,7 +354,7 @@ class Translator(object):
                         context.set_field_var(header_name, field_name,
                                               sym_packet.extract(
                                                   new_pos + extract_offset,
-                                                  field.size))
+                                                  field.size, label=label))
                         extract_offset += BitVecVal(field.size, 32)
                 else:
                     context.set_valid_field(header_name)

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -245,10 +245,10 @@ class Translator(object):
             # Map bits from packet to context
             extract_offset = BitVecVal(0, 32)
             for field_name, field in header_type.fields.items():
-                context.set_field_value(header_name, field_name,
-                                        sym_packet.extract(
-                                            new_pos + extract_offset,
-                                            field.size))
+                context.set_field_var(header_name, field_name,
+                                      sym_packet.extract(
+                                          new_pos + extract_offset,
+                                          field.size))
                 extract_offset += BitVecVal(field.size, 32)
 
             return new_pos + extract_offset
@@ -345,14 +345,14 @@ class Translator(object):
                         field_size_c = BitVecVal(field.size, sym_size.size())
                         constraints.append(ULE(sym_size, field_size_c))
                         context.record_extract_vl(header_name, field_name, sym_size)
-                        context.set_field_value(header_name, field_name,
-                                                field_val)
+                        context.set_field_var(header_name, field_name,
+                                              field_val)
                         extract_offset += sym_size
                     else:
-                        context.set_field_value(header_name, field_name,
-                                                sym_packet.extract(
-                                                    new_pos + extract_offset,
-                                                    field.size))
+                        context.set_field_var(header_name, field_name,
+                                              sym_packet.extract(
+                                                  new_pos + extract_offset,
+                                                  field.size))
                         extract_offset += BitVecVal(field.size, 32)
                 else:
                     context.set_valid_field(header_name)

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -202,6 +202,14 @@ def main():
         """With this option given, consolidate test-cases around common tables up to the maximum value given (omit value for unlimited).  Currently incompatible with max_test_cases_per_path != 1."""
     )
     parser.add_argument(
+        '-rnd', '--randomize',
+        dest='randomize',
+        action='store_true',
+        default=False,
+        help=
+        """With this option given, randomize the generated test-case data where possible."""
+    )
+    parser.add_argument(
         dest='input_file', type=str, help='Provide the path to the input file')
 
     # Parse the input arguments

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -63,6 +63,7 @@ def load_test_config(no_packet_length_errs=True,
     config.output_path = './test-case'
     config.extract_vl_variation = None
     config.consolidate_tables = None
+    config.randomize = False
 
 
 def run_test(json_filename):


### PR DESCRIPTION
Adds option to randomize free bits in variables.  Without this option, z3 has a tendency to prefer to set free variables to zero, which limits test coverage.

This PR also drops intermediate variables for packet extractions and SMT assignments, which turned out to result in a large performance boost.

We have observed that this option does not perform as well as intended on z3 versions newer than 4.8.4.0 due to some tuning of the QF_UFBV solver.  If using z3 versions newer than this then the targeted randomization test will fail due to insufficient variation in the packet payload.  We are currently considering a solution.