### PR TITLE
for-upstream/stack-oob-error

### DIFF
--- a/examples/header-stack-in-select.json
+++ b/examples/header-stack-in-select.json
@@ -1,0 +1,335 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "some_hdr",
+      "id" : 2,
+      "fields" : [
+        ["val", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "hdr",
+      "id" : 2,
+      "header_type" : "some_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "stack[0]",
+      "id" : 3,
+      "header_type" : "some_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "stack",
+      "id" : 0,
+      "header_type" : "some_hdr",
+      "size" : 1,
+      "header_ids" : [3]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "hdr"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x01",
+              "mask" : null,
+              "next_state" : "extract_stack"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : "select_last"
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["hdr", "val"]
+            }
+          ]
+        },
+        {
+          "name" : "extract_stack",
+          "id" : 1,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : "select_last"
+            }
+          ],
+          "transition_key" : []
+        },
+        {
+          "name" : "select_last",
+          "id" : 2,
+          "parser_ops" : [],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x0101",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["hdr", "val"]
+            },
+            {
+              "type" : "stack_field",
+              "value" : ["stack", "val"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-in-select.p4",
+        "line" : 48,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "headerstackinselect53",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["hdr", "val"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "header-stack-in-select.p4",
+            "line" : 53,
+            "column" : 8,
+            "source_fragment" : "h.hdr.val = 0"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "header-stack-in-select.p4",
+        "line" : 49,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_headerstackinselect53",
+      "tables" : [
+        {
+          "name" : "tbl_headerstackinselect53",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "header-stack-in-select.p4",
+            "line" : 53,
+            "column" : 18,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["headerstackinselect53"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "headerstackinselect53" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : []
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "header-stack-in-select.p4",
+        "line" : 46,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./header-stack-in-select.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/header-stack-in-select.p4
+++ b/examples/header-stack-in-select.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test checks that .last members of header stacks are handled correctly
+ * in select() blocks. */
+
+header some_hdr {
+    bit<8> val;
+}
+
+struct Header_t {
+    some_hdr hdr;
+    some_hdr[1] stack;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.hdr);
+        transition select(h.hdr.val) {
+            0x01: extract_stack;
+            default: select_last;
+        }
+    }
+
+    state extract_stack {
+        /* Read packet data into the first element of the header stack. */
+        b.extract(h.stack.next);
+        transition select_last;
+    }
+
+    state select_last {
+        /* Depending on the path taken to reach this state, h.stack might be
+         * empty, in which case h.stack.last will raise a StackOutOfBounds
+         * error.  The compiler warns about a potential uninitiaized read. */
+        transition select(h.hdr.val, h.stack.last.val) {
+            (0x01, 0x01): accept;
+        }
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Empty ingress blocks are not supported, so do something trivial. */
+    apply {
+        h.hdr.val = 0;
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -267,6 +267,9 @@ class Context:
         self.parsed_stacks[header_name] += 1
         return name
 
+    def get_stack_parsed_count(self, header_name):
+        return self.parsed_stacks[header_name]
+
     def set_valid_field(self, header_name):
         # Even though the P4_16 isValid() method
         # returns a boolean value, it appears that

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -133,7 +133,7 @@ class PathSolver(object):
             [str(n) for n in list(parser_path)])))
         for path_transition in parser_path:
             assert isinstance(path_transition, ParserTransition) or isinstance(
-                path_transition, ParserOpTransition)
+                path_transition, ParserErrorTransition)
 
             node = path_transition.src
             next_node = path_transition.dst
@@ -145,7 +145,7 @@ class PathSolver(object):
             for op_idx, parser_op in enumerate(parse_state.parser_ops):
                 fail = ''
                 if isinstance(
-                        path_transition, ParserOpTransition
+                        path_transition, ParserErrorTransition
                 ) and op_idx == path_transition.op_idx and path_transition.next_state == 'sink':
                     fail = path_transition.error_str
                     skip_select = True

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -129,7 +129,7 @@ class PathSolver(object):
         # XXX: make this work for multiple parsers
         parser = self.hlir.parsers['parser']
         pos = BitVecVal(0, 32)
-        logging.info('path = {}'.format(' -> '.join(
+        logging.info('path = {}'.format(', '.join(
             [str(n) for n in list(parser_path)])))
         for path_transition in parser_path:
             assert isinstance(path_transition, ParserTransition) or isinstance(
@@ -137,7 +137,7 @@ class PathSolver(object):
 
             node = path_transition.src
             next_node = path_transition.dst
-            logging.debug('{} -> {}\tpos = {}'.format(node, next_node, pos))
+            logging.debug('{}\tpos = {}'.format(path_transition, pos))
             new_pos = pos
             parse_state = parser.parse_states[node]
             context = self.current_context()

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -85,7 +85,10 @@ class PathCoverageGraphVisitor(GraphVisitor):
     def generate_test_case(self, control_path, is_complete_control_path):
         self.path_solver.push()
 
-        expected_path = self.path_solver.translator.expected_path(self.parser_path, control_path)
+        expected_path = list(
+            self.path_solver.translator.expected_path(self.parser_path,
+                                                      control_path)
+        )
         path_id = self.path_solver.path_id
 
         logging_str = "%d Exp path (len %d+%d=%d) complete_path %s: %s" % \

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -44,17 +44,15 @@ class ParserGraphVisitor(GraphVisitor):
             for e in path_prefix:
                 self.count(stack_counts, e.dst)
 
-        # Check whether the path so far involves an extraction beyond the
-        # end of a header stack.  In this case, the only legal onward
-        # transition is the StackOutOfBounds error.  If the -epl option is not
-        # in force, we won't have generated such a transition and the returned
-        # list will be empty, which will cause the caller to drop the current
-        # path-prefix entirely.
+        # Check whether the path so far involves an extraction beyond the end
+        # of a header stack.  In this case, the only legal onward transitions
+        # are error transitions.  If there are no such transitions, the
+        # returned list will be empty, which will cause the caller to drop the
+        # current path-prefix entirely.
         if any(self.hlir.get_header_stack(stack).size < count
                for stack, count in stack_counts.iteritems()):
             return [edge for edge in onward_edges
-                    if isinstance(edge, ParserErrorTransition) and
-                    edge.error_str == 'StackOutOfBounds']
+                    if isinstance(edge, ParserErrorTransition)]
 
         # Otherwise, no further filtering is necessary.
         return list(onward_edges)

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -60,10 +60,10 @@ def p4_value_to_bv(value, size):
             value.__class__))
 
 
-def parser_op_trans_to_str(op_trans):
+def parser_error_trans_to_str(error_trans):
     # XXX: after unifying type value representations
-    # assert isinstance(op_trans.op.value[1], TypeValueHexstr)
-    return op_trans.error_str
+    # assert isinstance(error_trans.op.value[1], TypeValueHexstr)
+    return error_trans.error_str
 
 
 class Translator(object):
@@ -630,7 +630,7 @@ class Translator(object):
     @staticmethod
     def expected_path(parser_path, control_path):
         expected_path = [
-            n.src if not isinstance(n, ParserOpTransition) else
-            parser_op_trans_to_str(n) for n in parser_path
+            n.src if not isinstance(n, ParserErrorTransition) else
+            parser_error_trans_to_str(n) for n in parser_path
         ] + ['sink'] + [(n.src, n) for n in control_path]
         return expected_path

--- a/src/p4pktgen/hlir/transition.py
+++ b/src/p4pktgen/hlir/transition.py
@@ -3,7 +3,7 @@ from p4pktgen.util.graph import Edge
 
 TransitionType = Enum(
     'TransitionType',
-    'PARSER_OP_TRANSITION ACTION_TRANSITION CONST_ACTION_TRANSITION BOOL_TRANSITION'
+    'PARSER_ERROR_TRANSITION ACTION_TRANSITION CONST_ACTION_TRANSITION BOOL_TRANSITION'
 )
 
 
@@ -45,10 +45,10 @@ class ParserTransition(Edge):
                     self.mask == other.mask) and (self.value == other.value)
 
 
-class ParserOpTransition(Transition):
+class ParserErrorTransition(Transition):
     def __init__(self, state_name, op, op_idx, next_state, error_str):
-        super(ParserOpTransition, self).__init__(
-            TransitionType.PARSER_OP_TRANSITION, state_name, next_state)
+        super(ParserErrorTransition, self).__init__(
+            TransitionType.PARSER_ERROR_TRANSITION, state_name, next_state)
         self.op = op
         self.op_idx = op_idx
         self.next_state = next_state

--- a/src/p4pktgen/hlir/transition.py
+++ b/src/p4pktgen/hlir/transition.py
@@ -54,6 +54,8 @@ class ParserErrorTransition(Transition):
         self.next_state = next_state
         self.error_str = error_str
 
+    def __repr__(self):
+        return '{} -({})-> {}'.format(self.src, self.error_str, self.dst)
 
 class ActionTransition(Transition):
     def __init__(self, src, dest, action, default_entry, action_data):

--- a/src/p4pktgen/hlir/type_value.py
+++ b/src/p4pktgen/hlir/type_value.py
@@ -10,6 +10,9 @@ class TypeValueExpression(TypeValue):
         # cond only exists for the ternary operator '?'
         if 'cond' in json_obj:
             self.cond = parse_type_value(json_obj['cond'])
+            assert self.cond is not None
+        else:
+            self.cond = None
         if json_obj['left'] is None:
             self.left = None
         else:
@@ -17,7 +20,7 @@ class TypeValueExpression(TypeValue):
         self.right = parse_type_value(json_obj['right'])
 
     def __repr__(self):
-        if hasattr(self, 'cond'):
+        if self.cond is not None:
             return '({} {} : {})'.format(self.cond, self.op, self.left,
                                          self.right)
         else:

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -216,9 +216,7 @@ class HLIR_Parse_States(object):
         self.transitions = []
         self.transition_key = []
 
-        # List of lists of transitions from parser operators. Every
-        # element in the list corresponds to a list of transitions from
-        # the parser operator with the same index.
+        # List of error transitions from parser operators in this state.
         self.parser_error_transitions = []
 
         # The header stacks that this parser state is extracting into.
@@ -361,28 +359,25 @@ class P4_HLIR(object):
 
                     if parser_op.op == P4ParserOpsEnum.verify:
                         error_str = self.id_to_errors[parser_op.value[1].value]
-                        p4ps.parser_error_transitions.append([
+                        p4ps.parser_error_transitions.append(
                             ParserErrorTransition(p4ps.name, parser_op, i,
                                                   'sink', error_str)
-                        ])
-                    elif not (Config().get_no_packet_length_errs()
-                              ) and parser_op.op == P4ParserOpsEnum.extract:
-                        p4ps.parser_error_transitions.append([
-                            ParserErrorTransition(p4ps.name, parser_op, i,
-                                                  'sink', 'PacketTooShort')
-                        ])
-                    elif not (Config().get_no_packet_length_errs(
-                    )) and parser_op.op == P4ParserOpsEnum.extract_VL:
-                        p4ps.parser_error_transitions.append([
-                            ParserErrorTransition(p4ps.name, parser_op, i,
-                                                  'sink', 'PacketTooShort')
-                        ])
-                        p4ps.parser_error_transitions.append([
-                            ParserErrorTransition(p4ps.name, parser_op, i,
-                                                  'sink', 'HeaderTooShort')
-                        ])
-                    else:
-                        p4ps.parser_error_transitions.append([])
+                        )
+                    elif not Config().get_no_packet_length_errs():
+                        if parser_op.op == P4ParserOpsEnum.extract:
+                            p4ps.parser_error_transitions.append(
+                                ParserErrorTransition(p4ps.name, parser_op, i,
+                                                      'sink', 'PacketTooShort')
+                            )
+                        elif parser_op.op == P4ParserOpsEnum.extract_VL:
+                            p4ps.parser_error_transitions.append(
+                                ParserErrorTransition(p4ps.name, parser_op, i,
+                                                      'sink', 'PacketTooShort')
+                            )
+                            p4ps.parser_error_transitions.append(
+                                ParserErrorTransition(p4ps.name, parser_op, i,
+                                                      'sink', 'HeaderTooShort')
+                            )
 
                     p4ps.parser_ops.append(parser_op)
 
@@ -473,9 +468,8 @@ class P4_HLIR(object):
                     graph.add_edge(ps_name, tns.next_state.name, tns)
                 else:
                     graph.add_edge(ps_name, 'sink', tns)
-            for parser_error_transitions in ps.parser_error_transitions:
-                for transition in parser_error_transitions:
-                    graph.add_edge(ps_name, transition.next_state, transition)
+            for transition in ps.parser_error_transitions:
+                graph.add_edge(ps_name, transition.next_state, transition)
 
         return graph
 

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -187,6 +187,12 @@ class HLIR_Parser_Ops(object):
             raise Exception(
                 'Unexpected op: {}'.format(json_op['op']))
 
+        if self.op == P4ParserOpsEnum.primitive:
+            self.value = [PrimitiveCall(json_op['parameters'][0])]
+        else:
+            self.value = [parse_type_value(pair)
+                          for pair in json_op['parameters']]
+
 
 class HLIR_Parse_States(object):
     """
@@ -347,13 +353,6 @@ class P4_HLIR(object):
                 p4ps = HLIR_Parse_States(parse_state)
                 for i, k in enumerate(parse_state['parser_ops']):
                     parser_op = HLIR_Parser_Ops(k)
-
-                    if parser_op.op == P4ParserOpsEnum.primitive:
-                        parser_op.value = [PrimitiveCall(k['parameters'][0])]
-                    else:
-                        parser_op.value = []
-                        for pair in k['parameters']:
-                            parser_op.value.append(parse_type_value(pair))
 
                     if (parser_op.op == P4ParserOpsEnum.extract or
                         parser_op.op == P4ParserOpsEnum.extract_VL) \

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -213,7 +213,7 @@ class HLIR_Parse_States(object):
         # List of lists of transitions from parser operators. Every
         # element in the list corresponds to a list of transitions from
         # the parser operator with the same index.
-        self.parser_ops_transitions = []
+        self.parser_error_transitions = []
 
         # The header stacks that this parser state is extracting into.
         # This is used for constructing the parser paths.
@@ -362,28 +362,28 @@ class P4_HLIR(object):
 
                     if parser_op.op == P4ParserOpsEnum.verify:
                         error_str = self.id_to_errors[parser_op.value[1].value]
-                        p4ps.parser_ops_transitions.append([
-                            ParserOpTransition(p4ps.name, parser_op, i, 'sink',
-                                               error_str)
+                        p4ps.parser_error_transitions.append([
+                            ParserErrorTransition(p4ps.name, parser_op, i,
+                                                  'sink', error_str)
                         ])
                     elif not (Config().get_no_packet_length_errs()
                               ) and parser_op.op == P4ParserOpsEnum.extract:
-                        p4ps.parser_ops_transitions.append([
-                            ParserOpTransition(p4ps.name, parser_op, i, 'sink',
-                                               'PacketTooShort')
+                        p4ps.parser_error_transitions.append([
+                            ParserErrorTransition(p4ps.name, parser_op, i,
+                                                  'sink', 'PacketTooShort')
                         ])
                     elif not (Config().get_no_packet_length_errs(
                     )) and parser_op.op == P4ParserOpsEnum.extract_VL:
-                        p4ps.parser_ops_transitions.append([
-                            ParserOpTransition(p4ps.name, parser_op, i, 'sink',
-                                               'PacketTooShort')
+                        p4ps.parser_error_transitions.append([
+                            ParserErrorTransition(p4ps.name, parser_op, i,
+                                                  'sink', 'PacketTooShort')
                         ])
-                        p4ps.parser_ops_transitions.append([
-                            ParserOpTransition(p4ps.name, parser_op, i, 'sink',
-                                               'HeaderTooShort')
+                        p4ps.parser_error_transitions.append([
+                            ParserErrorTransition(p4ps.name, parser_op, i,
+                                                  'sink', 'HeaderTooShort')
                         ])
                     else:
-                        p4ps.parser_ops_transitions.append([])
+                        p4ps.parser_error_transitions.append([])
 
                     p4ps.parser_ops.append(parser_op)
 
@@ -474,8 +474,8 @@ class P4_HLIR(object):
                     graph.add_edge(ps_name, tns.next_state.name, tns)
                 else:
                     graph.add_edge(ps_name, 'sink', tns)
-            for parser_op_transitions in ps.parser_ops_transitions:
-                for transition in parser_op_transitions:
+            for parser_error_transitions in ps.parser_error_transitions:
+                for transition in parser_error_transitions:
                     graph.add_edge(ps_name, transition.next_state, transition)
 
         return graph

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -2,9 +2,10 @@ from collections import OrderedDict
 import json
 import pytest
 
-from p4pktgen.main import generate_test_cases, path_tuple
+from p4pktgen.main import generate_test_cases
 from p4pktgen.config import Config
 from p4pktgen.core.test_cases import TestPathResult
+from p4pktgen.core.translator import Translator
 
 
 def load_test_config(no_packet_length_errs=True,
@@ -70,7 +71,8 @@ def load_test_config(no_packet_length_errs=True,
 
 def run_test(json_filename):
     return {
-        path_tuple(parser_path, control_path): result
+        tuple(Translator.expected_path(parser_path, control_path,
+                                       substitute_errors=False)): result
         for ((parser_path, control_path), result) in
             generate_test_cases(json_filename).iteritems()
     }
@@ -315,6 +317,10 @@ class CheckSystem:
             TestPathResult.NO_PACKET_FOUND,
             ('start', u'parse_ipv4', 'sink', (u'node_2', (False, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()')))):
             TestPathResult.SUCCESS,
+            ('start', u'parse_ipv4', 'IPv4IncorrectVersion', 'sink', (u'node_2', (True, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()')))):
+            TestPathResult.NO_PACKET_FOUND,
+            ('start', u'parse_ipv4', 'IPv4IncorrectVersion', 'sink', (u'node_2', (False, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()')))):
+            TestPathResult.SUCCESS,
             ('start', 'sink', (u'node_2', (True, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'sink', (u'node_2', (False, (u'checksum-ipv4-with-options.p4', 125, u'hdr.ipv4.isValid() && hdr.tcp.isValid()')))):
@@ -374,21 +380,25 @@ class CheckSystem:
         results = run_test(
             'examples/parser-impossible-transitions2.json')
         expected_results = {
-            ('start', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
+            ('start', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.SUCCESS,
-            ('start', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
+            ('start', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'parse_h5', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (False, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff')))):
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (True, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff'))), (u'tbl_parserimpossibletransitions2l130', u'parserimpossibletransitions2l130')):
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (False, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff')))):
+            TestPathResult.NO_PACKET_FOUND,
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (True, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff'))), (u'tbl_parserimpossibletransitions2l130', u'parserimpossibletransitions2l130')):
             TestPathResult.SUCCESS,
-            ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (True, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()')))):
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (True, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (True, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()')))):
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (True, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (True, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()')))):
+            TestPathResult.NO_PACKET_FOUND,
+            ('start', 'parse_h5', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (True, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'parse_h5', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
@@ -398,15 +408,17 @@ class CheckSystem:
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'parse_h1', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (False, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff')))):
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (True, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff'))), (u'tbl_parserimpossibletransitions2l130', u'parserimpossibletransitions2l130')):
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (False, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff')))):
+            TestPathResult.NO_PACKET_FOUND,
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (False, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()'))), (u'node_15', (True, (u'parser-impossible-transitions2.p4', 126, u'hdr.ethernet.dstAddr == 0xffffffff'))), (u'tbl_parserimpossibletransitions2l130', u'parserimpossibletransitions2l130')):
             TestPathResult.SUCCESS,
-            ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (True, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()')))):
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (False, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()'))), (u'node_8', (True, (u'parser-impossible-transitions2.p4', 116, u'hdr.h2.isValid() || hdr.h3.isValid() || hdr.h4.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (True, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()')))):
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()'))), (u'node_6', (True, (u'parser-impossible-transitions2.p4', 114, u'hdr.h5.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
-            ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (True, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()')))):
+            ('start', 'parse_h1', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (True, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,
             ('start', 'parse_h1', 'sink', (u'node_2', (True, (u'parser-impossible-transitions2.p4', 110, u'hdr.ethernet.isValid()'))), (u'tbl_parserimpossibletransitions2l111', u'parserimpossibletransitions2l111'), (u'node_4', (False, (u'parser-impossible-transitions2.p4', 112, u'hdr.h1.isValid()')))):
             TestPathResult.NO_PACKET_FOUND,


### PR DESCRIPTION
Support for extraction to header stacks was added in a previous PR.  This PR adds support for Stack Out Of Bounds error paths.
If an extraction to a stack may cause this error then this adds a new error path that p4pktgen will build a test case for.