### PR TITLE
for-upstream/parser-error-metadata

### DIFF
--- a/examples/parser-error.json
+++ b/examples/parser-error.json
@@ -1,0 +1,595 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp", 32, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "length_hdr",
+      "id" : 2,
+      "fields" : [
+        ["length", 8, false]
+      ]
+    },
+    {
+      "name" : "variable_length_hdr",
+      "id" : 3,
+      "fields" : [
+        ["content", "*"]
+      ],
+      "max_length" : 1
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "length",
+      "id" : 2,
+      "header_type" : "length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "stack_vl[0]",
+      "id" : 3,
+      "header_type" : "variable_length_hdr",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [
+    {
+      "name" : "stack_vl",
+      "id" : 0,
+      "header_type" : "variable_length_hdr",
+      "size" : 1,
+      "header_ids" : [3]
+    }
+  ],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "length"
+                }
+              ],
+              "op" : "extract"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "field",
+                  "value" : ["scalars", "tmp"]
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "expression",
+                    "value" : {
+                      "op" : "&",
+                      "left" : {
+                        "type" : "field",
+                        "value" : ["length", "length"]
+                      },
+                      "right" : {
+                        "type" : "hexstr",
+                        "value" : "0xffffffff"
+                      }
+                    }
+                  }
+                }
+              ],
+              "op" : "set"
+            },
+            {
+              "parameters" : [
+                {
+                  "type" : "stack",
+                  "value" : "stack_vl"
+                },
+                {
+                  "type" : "expression",
+                  "value" : {
+                    "type" : "field",
+                    "value" : ["scalars", "tmp"]
+                  }
+                }
+              ],
+              "op" : "extract_VL"
+            }
+          ],
+          "transitions" : [
+            {
+              "type" : "hexstr",
+              "value" : "0x08",
+              "mask" : null,
+              "next_state" : "start"
+            },
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : [
+            {
+              "type" : "field",
+              "value" : ["length", "length"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser-error.p4",
+        "line" : 38,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "parsererror46",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 46,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "parsererror48",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 48,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "parsererror50",
+      "id" : 2,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "parsererror52",
+      "id" : 3,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "mark_to_drop",
+          "parameters" : [
+            {
+              "type" : "header",
+              "value" : "standard_metadata"
+            }
+          ],
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 52,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "parser-error.p4",
+        "line" : 39,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "node_2",
+      "tables" : [
+        {
+          "name" : "tbl_parsererror46",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 46,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["parsererror46"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "parsererror46" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_parsererror48",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 48,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["parsererror48"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "parsererror48" : null
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_parsererror50",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [2],
+          "actions" : ["parsererror50"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "parsererror50" : null
+          },
+          "default_entry" : {
+            "action_id" : 2,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_parsererror52",
+          "id" : 3,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 52,
+            "column" : 12,
+            "source_fragment" : "mark_to_drop(standard_meta)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [3],
+          "actions" : ["parsererror52"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "parsererror52" : null
+          },
+          "default_entry" : {
+            "action_id" : 3,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_2",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 45,
+            "column" : 12,
+            "source_fragment" : "standard_meta.parser_error == error.NoError"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x0"
+              }
+            }
+          },
+          "true_next" : "tbl_parsererror46",
+          "false_next" : "node_4"
+        },
+        {
+          "name" : "node_4",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 47,
+            "column" : 17,
+            "source_fragment" : "standard_meta.parser_error == error.PacketTooShort"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x1"
+              }
+            }
+          },
+          "true_next" : "tbl_parsererror48",
+          "false_next" : "node_6"
+        },
+        {
+          "name" : "node_6",
+          "id" : 2,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 49,
+            "column" : 17,
+            "source_fragment" : "standard_meta.parser_error == error.HeaderTooShort"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x4"
+              }
+            }
+          },
+          "true_next" : "tbl_parsererror50",
+          "false_next" : "node_8"
+        },
+        {
+          "name" : "node_8",
+          "id" : 3,
+          "source_info" : {
+            "filename" : "parser-error.p4",
+            "line" : 51,
+            "column" : 17,
+            "source_fragment" : "standard_meta.parser_error == error.StackOutOfBounds"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["standard_metadata", "parser_error"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x3"
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_parsererror52"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "parser-error.p4",
+        "line" : 36,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "./parser-error.p4i",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/parser-error.p4
+++ b/examples/parser-error.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This test checks that the parser_error standard metadata field is handled
+ * correctly. */
+
+header length_hdr {
+    bit<8> length;
+}
+header variable_length_hdr {
+    varbit<8> content;
+}
+struct Header_t {
+    length_hdr length;
+    variable_length_hdr[1] stack_vl;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        /* NoError, PacketTooShort, HeaderTooShort and StackOutOfBounds are all
+         * possible here. */
+        b.extract(h.length);
+        b.extract(h.stack_vl.next, (bit<32>) h.length.length);
+        transition select(h.length.length) {
+            0x08: start;
+            default: accept;
+        }
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    /* Check the the parser_error metadata field is handled correctly by
+     * sending packets down different paths according to the value of that
+     * field. */
+    apply {
+        if (standard_meta.parser_error == error.NoError)
+            mark_to_drop(standard_meta);
+        else if (standard_meta.parser_error == error.PacketTooShort)
+            mark_to_drop(standard_meta);
+        else if (standard_meta.parser_error == error.HeaderTooShort)
+            mark_to_drop(standard_meta);
+        else if (standard_meta.parser_error == error.StackOutOfBounds)
+            mark_to_drop(standard_meta);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -363,8 +363,14 @@ class P4_HLIR(object):
 
         # Get the mapping of error ids to error strings
         self.id_to_errors = {}
-        for error in json_obj['errors']:
-            self.id_to_errors[int(error[1])] = error[0]
+        self.errors_to_id = {}
+        for error, id_str in json_obj['errors']:
+            self.id_to_errors[int(id_str)] = error
+            self.errors_to_id[error] = int(id_str)
+        assert 'NoError' in self.errors_to_id
+        assert 'PacketTooShort' in self.errors_to_id
+        assert 'HeaderTooShort' in self.errors_to_id
+        assert 'StackOutOfBounds' in self.errors_to_id
 
         self.parsers = OrderedDict()
         for p in json_obj['parsers']:

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -716,6 +716,38 @@ class CheckSystem:
         assert len(table_configs[0][0]) > 0, "Config has no commands"
 
 
+    def check_parser_error(self, config):
+        # This test case checks that the parser_error standard metadata field
+        # is set correctly.
+        load_test_config(no_packet_length_errs=False, **config)
+        results = run_test('examples/parser-error.json')
+        expected_results = {
+            # There is precisely one SUCCESS path through the program for each
+            # of the five parser paths.  The branch taken in the ingress path
+            # corresponds to the error in the parser path.
+            ('start', 'sink', (u'node_2', (True, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'tbl_parsererror46', u'parsererror46')): TestPathResult.SUCCESS,
+            ('start', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (True, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'tbl_parsererror48', u'parsererror48')): TestPathResult.SUCCESS,
+            ('start', 'HeaderTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'node_6', (True, (u'parser-error.p4', 49, u'standard_meta.parser_error == error.HeaderTooShort'))), (u'tbl_parsererror50', u'parsererror50')): TestPathResult.SUCCESS,
+            ('start', 'start', 'StackOutOfBounds', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'node_6', (False, (u'parser-error.p4', 49, u'standard_meta.parser_error == error.HeaderTooShort'))), (u'node_8', (True, (u'parser-error.p4', 51, u'standard_meta.parser_error == error.StackOutOfBounds'))), (u'tbl_parsererror52', u'parsererror52')): TestPathResult.SUCCESS,
+            ('start', 'start', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (True, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'tbl_parsererror48', u'parsererror48')): TestPathResult.SUCCESS,
+
+            # All other combinations are NO_PACKET_FOUND.
+            ('start', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'HeaderTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'node_6', (False, (u'parser-error.p4', 49, u'standard_meta.parser_error == error.HeaderTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'HeaderTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (True, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'HeaderTooShort', 'sink', (u'node_2', (True, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'PacketTooShort', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'PacketTooShort', 'sink', (u'node_2', (True, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'StackOutOfBounds', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'node_6', (False, (u'parser-error.p4', 49, u'standard_meta.parser_error == error.HeaderTooShort'))), (u'node_8', (False, (u'parser-error.p4', 51, u'standard_meta.parser_error == error.StackOutOfBounds')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'StackOutOfBounds', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (False, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort'))), (u'node_6', (True, (u'parser-error.p4', 49, u'standard_meta.parser_error == error.HeaderTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'StackOutOfBounds', 'sink', (u'node_2', (False, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError'))), (u'node_4', (True, (u'parser-error.p4', 47, u'standard_meta.parser_error == error.PacketTooShort')))): TestPathResult.NO_PACKET_FOUND,
+            ('start', 'start', 'StackOutOfBounds', 'sink', (u'node_2', (True, (u'parser-error.p4', 45, u'standard_meta.parser_error == error.NoError')))): TestPathResult.NO_PACKET_FOUND,
+        }
+        assert results == expected_results
+
+
     def check_empty_control_graph(self, config):
         # This test checks that p4pktgen can handle programs with empty control
         # graphs.


### PR DESCRIPTION
Allows generation of test-cases for programs that use the parser_error field in standard_metadata.