### PR TITLE
for-upstream/extern-support

### DIFF
--- a/examples/extern_custom_fields.json
+++ b/examples/extern_custom_fields.json
@@ -1,0 +1,364 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : [
+        ["tmp_0", 8, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    },
+    {
+      "name" : "abyte",
+      "id" : 2,
+      "fields" : [
+        ["data", 8, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "scalars",
+      "id" : 0,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 1,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "a",
+      "id" : 2,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "a"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "extern_custom_fields.p4",
+        "line" : 41,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "extern_custom_fields50",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["a", "data"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "extern_custom_fields.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "h.a.data = 0"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "extern_custom_fields48",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "_CustomExtern_apply_fields",
+          "parameters" : [
+            {
+              "type" : "extern",
+              "value" : "ingress.anexterninstance"
+            },
+            {
+              "type" : "field",
+              "value" : ["a", "data"]
+            },
+            {
+              "type" : "field",
+              "value" : ["scalars", "tmp_0"]
+            }
+          ],
+          "source_info" : {
+            "filename" : "extern_custom_fields.p4",
+            "line" : 48,
+            "column" : 8,
+            "source_fragment" : "anexterninstance.apply_fields(h.a.data, tmp)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "extern_custom_fields.p4",
+        "line" : 42,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_extern_custom_fields48",
+      "tables" : [
+        {
+          "name" : "tbl_extern_custom_fields48",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "extern_custom_fields.p4",
+            "line" : 48,
+            "column" : 8,
+            "source_fragment" : "anexterninstance.apply_fields(h.a.data, tmp)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["extern_custom_fields48"],
+          "base_default_next" : "node_3",
+          "next_tables" : {
+            "extern_custom_fields48" : "node_3"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_extern_custom_fields50",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "extern_custom_fields.p4",
+            "line" : 50,
+            "column" : 21,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["extern_custom_fields50"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "extern_custom_fields50" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_3",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "extern_custom_fields.p4",
+            "line" : 49,
+            "column" : 11,
+            "source_fragment" : "tmp == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["scalars", "tmp_0"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_extern_custom_fields50"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "extern_custom_fields.p4",
+        "line" : 39,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [
+    {
+      "name" : "ingress.anexterninstance",
+      "id" : 0,
+      "type" : "CustomExtern",
+      "attribute_values" : [
+        {
+          "name" : "x",
+          "type" : "hexstr",
+          "value" : "0x5"
+        }
+      ]
+    }
+  ],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "extern_custom_fields.p4",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/extern_custom_fields.p4
+++ b/examples/extern_custom_fields.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This program allows basic tests of an extern that modifies individual fields.
+ * Note that the default `p4c` compiler cannot compile programs with externs,
+ * this program must be compiled with `p4c-bm2-ss --emit-externs`.
+ */
+
+header abyte {
+    bit<8> data;
+}
+
+ /* Note that CustomExtern is generic and makes no indication of what the extern
+  * actually does.  This is intentional as we expect to have to deal with cases
+  * like this. */
+extern CustomExtern {
+    CustomExtern(bit<16> x);  // constructor
+    // an extern function, takes two bytes, modifies the second in some way.
+    void apply_fields(in bit<8> data_in, out bit<8> result);
+}
+
+struct Header_t {
+    abyte a;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.a);
+        transition accept;
+    }
+}
+
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    CustomExtern(5) anexterninstance;
+    bit<8> tmp;
+
+    apply {
+        anexterninstance.apply_fields(h.a.data, tmp);
+        if(tmp == 0) {
+            h.a.data = 0;
+        }
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/extern_custom_headers.json
+++ b/examples/extern_custom_headers.json
@@ -1,0 +1,369 @@
+{
+  "header_types" : [
+    {
+      "name" : "scalars_0",
+      "id" : 0,
+      "fields" : []
+    },
+    {
+      "name" : "abyte",
+      "id" : 1,
+      "fields" : [
+        ["data", 8, false]
+      ]
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "fields" : [
+        ["ingress_port", 9, false],
+        ["egress_spec", 9, false],
+        ["egress_port", 9, false],
+        ["instance_type", 32, false],
+        ["packet_length", 32, false],
+        ["enq_timestamp", 32, false],
+        ["enq_qdepth", 19, false],
+        ["deq_timedelta", 32, false],
+        ["deq_qdepth", 19, false],
+        ["ingress_global_timestamp", 48, false],
+        ["egress_global_timestamp", 48, false],
+        ["mcast_grp", 16, false],
+        ["egress_rid", 16, false],
+        ["checksum_error", 1, false],
+        ["parser_error", 32, false],
+        ["priority", 3, false],
+        ["_padding", 3, false]
+      ]
+    }
+  ],
+  "headers" : [
+    {
+      "name" : "tmp_0",
+      "id" : 0,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    },
+    {
+      "name" : "scalars",
+      "id" : 1,
+      "header_type" : "scalars_0",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "standard_metadata",
+      "id" : 2,
+      "header_type" : "standard_metadata",
+      "metadata" : true,
+      "pi_omit" : true
+    },
+    {
+      "name" : "a",
+      "id" : 3,
+      "header_type" : "abyte",
+      "metadata" : false,
+      "pi_omit" : true
+    }
+  ],
+  "header_stacks" : [],
+  "header_union_types" : [],
+  "header_unions" : [],
+  "header_union_stacks" : [],
+  "field_lists" : [],
+  "errors" : [
+    ["NoError", 0],
+    ["PacketTooShort", 1],
+    ["NoMatch", 2],
+    ["StackOutOfBounds", 3],
+    ["HeaderTooShort", 4],
+    ["ParserTimeout", 5],
+    ["ParserInvalidArgument", 6]
+  ],
+  "enums" : [],
+  "parsers" : [
+    {
+      "name" : "parser",
+      "id" : 0,
+      "init_state" : "start",
+      "parse_states" : [
+        {
+          "name" : "start",
+          "id" : 0,
+          "parser_ops" : [
+            {
+              "parameters" : [
+                {
+                  "type" : "regular",
+                  "value" : "a"
+                }
+              ],
+              "op" : "extract"
+            }
+          ],
+          "transitions" : [
+            {
+              "value" : "default",
+              "mask" : null,
+              "next_state" : null
+            }
+          ],
+          "transition_key" : []
+        }
+      ]
+    }
+  ],
+  "parse_vsets" : [],
+  "deparsers" : [
+    {
+      "name" : "deparser",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "extern_custom_headers.p4",
+        "line" : 41,
+        "column" : 8,
+        "source_fragment" : "deparser"
+      },
+      "order" : [],
+      "primitives" : []
+    }
+  ],
+  "meter_arrays" : [],
+  "counter_arrays" : [],
+  "register_arrays" : [],
+  "calculations" : [],
+  "learn_lists" : [],
+  "actions" : [
+    {
+      "name" : "extern_custom_headers50",
+      "id" : 0,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "assign",
+          "parameters" : [
+            {
+              "type" : "field",
+              "value" : ["a", "data"]
+            },
+            {
+              "type" : "hexstr",
+              "value" : "0x00"
+            }
+          ],
+          "source_info" : {
+            "filename" : "extern_custom_headers.p4",
+            "line" : 50,
+            "column" : 12,
+            "source_fragment" : "h.a.data = 0"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "extern_custom_headers48",
+      "id" : 1,
+      "runtime_data" : [],
+      "primitives" : [
+        {
+          "op" : "_CustomExtern_apply_headers",
+          "parameters" : [
+            {
+              "type" : "extern",
+              "value" : "ingress.anexterninstance"
+            },
+            {
+              "type" : "header",
+              "value" : "a"
+            },
+            {
+              "type" : "header",
+              "value" : "tmp_0"
+            }
+          ],
+          "source_info" : {
+            "filename" : "extern_custom_headers.p4",
+            "line" : 48,
+            "column" : 8,
+            "source_fragment" : "anexterninstance.apply_headers(h.a, tmp)"
+          }
+        }
+      ]
+    }
+  ],
+  "pipelines" : [
+    {
+      "name" : "ingress",
+      "id" : 0,
+      "source_info" : {
+        "filename" : "extern_custom_headers.p4",
+        "line" : 42,
+        "column" : 8,
+        "source_fragment" : "ingress"
+      },
+      "init_table" : "tbl_extern_custom_headers48",
+      "tables" : [
+        {
+          "name" : "tbl_extern_custom_headers48",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "extern_custom_headers.p4",
+            "line" : 48,
+            "column" : 8,
+            "source_fragment" : "anexterninstance.apply_headers(h.a, tmp)"
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [1],
+          "actions" : ["extern_custom_headers48"],
+          "base_default_next" : "node_3",
+          "next_tables" : {
+            "extern_custom_headers48" : "node_3"
+          },
+          "default_entry" : {
+            "action_id" : 1,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        },
+        {
+          "name" : "tbl_extern_custom_headers50",
+          "id" : 1,
+          "source_info" : {
+            "filename" : "extern_custom_headers.p4",
+            "line" : 50,
+            "column" : 21,
+            "source_fragment" : "="
+          },
+          "key" : [],
+          "match_type" : "exact",
+          "type" : "simple",
+          "max_size" : 1024,
+          "with_counters" : false,
+          "support_timeout" : false,
+          "direct_meters" : null,
+          "action_ids" : [0],
+          "actions" : ["extern_custom_headers50"],
+          "base_default_next" : null,
+          "next_tables" : {
+            "extern_custom_headers50" : null
+          },
+          "default_entry" : {
+            "action_id" : 0,
+            "action_const" : true,
+            "action_data" : [],
+            "action_entry_const" : true
+          }
+        }
+      ],
+      "action_profiles" : [],
+      "conditionals" : [
+        {
+          "name" : "node_3",
+          "id" : 0,
+          "source_info" : {
+            "filename" : "extern_custom_headers.p4",
+            "line" : 49,
+            "column" : 11,
+            "source_fragment" : "tmp.data == 0"
+          },
+          "expression" : {
+            "type" : "expression",
+            "value" : {
+              "op" : "==",
+              "left" : {
+                "type" : "field",
+                "value" : ["tmp_0", "data"]
+              },
+              "right" : {
+                "type" : "hexstr",
+                "value" : "0x00"
+              }
+            }
+          },
+          "false_next" : null,
+          "true_next" : "tbl_extern_custom_headers50"
+        }
+      ]
+    },
+    {
+      "name" : "egress",
+      "id" : 1,
+      "source_info" : {
+        "filename" : "extern_custom_headers.p4",
+        "line" : 39,
+        "column" : 8,
+        "source_fragment" : "egress"
+      },
+      "init_table" : null,
+      "tables" : [],
+      "action_profiles" : [],
+      "conditionals" : []
+    }
+  ],
+  "checksums" : [],
+  "force_arith" : [],
+  "extern_instances" : [
+    {
+      "name" : "ingress.anexterninstance",
+      "id" : 0,
+      "type" : "CustomExtern",
+      "attribute_values" : [
+        {
+          "name" : "x",
+          "type" : "hexstr",
+          "value" : "0x5"
+        }
+      ]
+    }
+  ],
+  "field_aliases" : [
+    [
+      "queueing_metadata.enq_timestamp",
+      ["standard_metadata", "enq_timestamp"]
+    ],
+    [
+      "queueing_metadata.enq_qdepth",
+      ["standard_metadata", "enq_qdepth"]
+    ],
+    [
+      "queueing_metadata.deq_timedelta",
+      ["standard_metadata", "deq_timedelta"]
+    ],
+    [
+      "queueing_metadata.deq_qdepth",
+      ["standard_metadata", "deq_qdepth"]
+    ],
+    [
+      "intrinsic_metadata.ingress_global_timestamp",
+      ["standard_metadata", "ingress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.egress_global_timestamp",
+      ["standard_metadata", "egress_global_timestamp"]
+    ],
+    [
+      "intrinsic_metadata.mcast_grp",
+      ["standard_metadata", "mcast_grp"]
+    ],
+    [
+      "intrinsic_metadata.egress_rid",
+      ["standard_metadata", "egress_rid"]
+    ],
+    [
+      "intrinsic_metadata.priority",
+      ["standard_metadata", "priority"]
+    ]
+  ],
+  "program" : "extern_custom_headers.p4",
+  "__meta__" : {
+    "version" : [2, 18],
+    "compiler" : "https://github.com/p4lang/p4c"
+  }
+}

--- a/examples/extern_custom_headers.p4
+++ b/examples/extern_custom_headers.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/* This program allows basic tests of an extern that modifies whole headers.
+ * Note that the default `p4c` compiler cannot compile programs with externs,
+ * this program must be compiled with `p4c-bm2-ss --emit-externs`.
+ */
+
+header abyte {
+    bit<8> data;
+}
+
+ /* Note that CustomExtern is generic and makes no indication of what the extern
+  * actually does.  This is intentional as we expect to have to deal with cases
+  * like this. */
+extern CustomExtern {
+    CustomExtern(bit<16> x);  // constructor
+    // an extern function, takes two bytes, modifies the second in some way.
+    void apply_headers(in abyte data_in, out abyte result);
+}
+
+struct Header_t {
+    abyte a;
+}
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m,
+         inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.a);
+        transition accept;
+    }
+}
+
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m,
+               inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply {} }
+control ingress(inout Header_t h, inout Meta_t m,
+                inout standard_metadata_t standard_meta) {
+    CustomExtern(5) anexterninstance;
+    abyte tmp;
+
+    apply {
+        anexterninstance.apply_headers(h.a, tmp);
+        if(tmp.data == 0) {
+            h.a.data = 0;
+        }
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/examples/externs/rshift_extern.py
+++ b/examples/externs/rshift_extern.py
@@ -1,0 +1,53 @@
+import z3
+
+
+class CustomExtern(object):
+    """
+    Extern object with apply function that performs a rshift by n bytes.
+    Is deliberately written with generically named class and function as we
+    expect to mainly have to have to deal with these cases.
+    Arguments are passed into apply as a list to ensure that output arguments
+    can be modified by the function.  Note that as program json does not specify
+    which args are input/output the function must take care not to modify
+    input entries in args.
+    """
+    def __init__(self, n):
+        self.n = n
+
+    def rshift_bv(self, input, start_output):
+        assert z3.is_bv(input)
+        assert z3.is_bv(start_output)
+        assert input.size() == start_output.size()
+
+        return input >> self.n
+
+    def apply_fields(self, args):
+        """
+        Bitshifts a single field right by n.
+        Expects two arguments, both z3 BitVecs of same sizes.
+        """
+        assert len(args) == 2
+        input = args[0]
+        start_output = args[1]
+
+        output = self.rshift_bv(input, start_output)
+
+        args[1] = output
+
+    def apply_headers(self, args):
+        """
+        Bitshifts each field in a header right by n, with no carryover between
+        fields.
+        Expects two arguments, both lists of z3 BitVecs of same sizes.
+        """
+        input_list = args[0]
+        start_output_list = args[1]
+
+        assert isinstance(input_list, list)
+        assert isinstance(start_output_list, list)
+        assert len(input_list) == len(start_output_list)
+
+        output = [self.rshift_bv(input, start_output)
+                  for input, start_output in zip(input_list, start_output_list)]
+
+        args[1] = output

--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -32,6 +32,7 @@ class Config:
         self.extract_vl_variation = args.extract_vl_variation
         self.consolidate_tables = args.consolidate_tables
         self.randomize = args.randomize
+        self.extern_definitions = args.extern_definitions
 
     def get_debug(self):
         return self.debug
@@ -116,3 +117,8 @@ class Config:
 
     def get_randomize(self):
         return self.randomize
+
+    def get_extern_definitions(self):
+        if self.extern_definitions is None:
+            return {}
+        return dict(x.split(':', 1) for x in self.extern_definitions)

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -79,7 +79,7 @@ class Context:
         # Maps P4 variables to SMT expressions
         self.var_to_smt_val = {}
 
-        self.fields = {}
+        self.fields = {}  # {(header_name, field_name): HLIR_Field, ...}
         # XXX: unify errors
         self.uninitialized_reads = []
         self.invalid_header_writes = []
@@ -214,9 +214,6 @@ class Context:
 
     def get_header_field(self, header_name, header_field):
         return self.get_var((header_name, header_field))
-
-    def get_header_field_size(self, header_name, header_field):
-        return self.get_header_field(header_name, header_field).size()
 
     def get_last_header_field(self, header_name, header_field, size):
         # XXX: size should not be a param

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -12,21 +12,6 @@ from z3 import *
 from p4pktgen.config import Config
 
 
-class ContextVar(object):
-    def __init__(self):
-        pass
-
-
-class Field(ContextVar):
-    def __init__(self, header, field):
-        super(ContextVar, self).__init__()
-        self.header = header
-        self.field = field
-
-    def __eq__(self, other):
-        return self.header == other.header and self.header == other.header
-
-
 class Variables(object):
     """Helper class for creating variables used to model input data.  It
     encapsulates the handling of the randomization of solutions found for
@@ -125,15 +110,12 @@ class Context:
         self.source_info = None
 
     def register_field(self, field):
-        self.fields[self.field_to_var(field)] = field
+        var_name = (field.header.name, field.name)
+        self.fields[var_name] = field
 
     def fresh_var(self, prefix, size):
         Context.next_id += 1
         return self.variables.new('{}_{}'.format(prefix, Context.next_id), size)
-
-    def field_to_var(self, field):
-        assert field.header is not None
-        return (field.header.name, field.name)
 
     def insert(self, field, sym_val):
         self.set_field_value(field.header.name, field.name, sym_val)

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -27,13 +27,13 @@ class PathSolver(object):
     allow an incremental approach with backtracking and efficient solving of
     graph edges."""
 
-    def __init__(self, json_file, hlir, pipeline):
+    def __init__(self, json_file, p4top, pipeline):
         self.solver = SolverFor('QF_UFBV')
         self.solver.push()
         self.solver_result = None
-        self.hlir = hlir
+        self.hlir = p4top.hlir
         self.pipeline = pipeline
-        self.translator = Translator(hlir, pipeline)
+        self.translator = Translator(p4top, pipeline)
         self.test_case_builder = TestCaseBuilder(json_file, pipeline)
         self.total_switch_time = 0.0
 

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -65,10 +65,11 @@ class Translator(object):
     fixed state after instantiation with the HLIR and pipeline it's translating
     for."""
 
-    def __init__(self, hlir, pipeline):
+    def __init__(self, p4top, pipeline):
         # These are used for necessary lookups and should be unchanged by any
         # operation on instances of this class.
-        self.hlir = hlir
+        self.hlir = p4top.hlir
+        self.externs = p4top.externs
         self.pipeline = pipeline
 
     def value_header_name_and_type(self, value):

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -529,13 +529,15 @@ class Translator(object):
                         context.set_field_value(dst_name, '$valid$', BitVecVal(0, 1))
                         context.remove_header_fields(dst_name)
 
-                elif (primitive.op in [
+                elif primitive.op in [
                         'modify_field_rng_uniform',
                         'modify_field_with_hash_based_offset',
                         'clone_ingress_pkt_to_egress',
-                        'clone_egress_pkt_to_egress', 'count', 'execute_meter',
-                        'generate_digest'
-                ] and Config().get_allow_unimplemented_primitives()):
+                        'clone_egress_pkt_to_egress', 'count',
+                        'execute_meter', 'generate_digest']:
+                    if not Config().get_allow_unimplemented_primitives():
+                        raise Exception('Primitive op {} only allowed with'
+                                        '--allow-unimplemented-primitives option')
                     logging.warning('Primitive op {} allowed but treated as no-op'.
                                     format(primitive.op))
                 else:

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -60,6 +60,18 @@ def p4_value_to_bv(value, size):
             value.__class__))
 
 
+def assert_bv_same_size(lhs, rhs):
+    assert z3.is_bv(lhs) and z3.is_bv(rhs)
+    assert lhs.size() == rhs.size()
+
+
+def assert_bv_list_same_size(lhs_list, rhs_list):
+    assert isinstance(lhs_list, list) and isinstance(rhs_list, list)
+    assert len(lhs_list) == len(rhs_list)
+    for lhs, rhs in zip(lhs_list, rhs_list):
+        assert_bv_same_size(lhs, rhs)
+
+
 class Translator(object):
     """Translates p4pktgen path objects into z3 representations.  Should have a
     fixed state after instantiation with the HLIR and pipeline it's translating
@@ -530,6 +542,28 @@ class Translator(object):
                         context.set_field_value(dst_name, '$valid$', BitVecVal(0, 1))
                         context.remove_header_fields(dst_name)
 
+                elif len(primitive.parameters) > 0 \
+                        and isinstance(primitive.parameters[0], TypeValueExtern):
+                    # extern action primitives have following layout
+                    # {'op': "_<extern-instance-type>_<function-name>",
+                    #  'parameters': [
+                    #    {'type': "extern", 'value': <extern-instance-name>},
+                    #    {<argument-1>}, {<argument-2>}, ...
+                    #  ],
+                    # 'source_info': ... }
+                    extern_instance = \
+                        self.hlir.get_extern_instance(primitive.parameters[0].extern_instance_name)
+                    op_prefix = '_{}_'.format(extern_instance.type)
+                    assert primitive.op.startswith(op_prefix), \
+                        "Unexpected op {} for extern call to instance of type {}".format(
+                            primitive.op, extern_instance.type
+                        )
+
+                    func_name = primitive.op[len(op_prefix):]
+                    func = self.externs.get_func(extern_instance, func_name)
+                    params = primitive.parameters[1:]
+                    self.extern_to_smt(context, func, params)
+
                 elif primitive.op in [
                         'modify_field_rng_uniform',
                         'modify_field_with_hash_based_offset',
@@ -546,6 +580,69 @@ class Translator(object):
                         'Primitive op {} not supported'.format(primitive.op))
 
                 context.unset_source_info()
+
+    def get_header_field_vars(self, header_name):
+        hlir_header = self.hlir.headers[header_name]
+        return [(header_name, field)
+                for field in hlir_header.fields.keys() if field != '$valid$']
+
+    def extern_to_smt(self, context, extern_func, params):
+        def get_var_wrapper(var_name):
+            # Out only params will typically not be initialised before the call.
+            # However, we don't know which params are in/out, so allow all to be
+            # uninitialised.
+            if var_name not in context.var_to_smt_val:
+                field = context.fields[var_name]
+                if field.hdr.metadata and Config().get_solve_for_metadata():
+                    # Will not cause uninitialized read, let get_var handle it.
+                    pass
+                else:
+                    return BitVecVal(0, field.size)
+            return context.get_var(var_name)
+
+        # Python backends model fields as BitVecs and headers as lists of
+        # BitVecs.  We need to convert the headers and fields to this format.
+        args = []
+        for param in params:
+            if isinstance(param, TypeValueField):
+                args.append(get_var_wrapper((param.header_name, param.header_field)))
+            else:
+                assert isinstance(param, TypeValueHeader)
+                field_var_names = self.get_header_field_vars(param.header_name)
+                args.append([get_var_wrapper(var_name)
+                            for var_name in field_var_names])
+        args_input = list(args)
+
+        # Call function.  Extern return value assignments cannot currently be
+        # converted into json, so ignore return value of extern function.
+        extern_func(args)
+
+        # Check that the args list still matches schema
+        assert len(args) == len(args_input)
+        for before, after in zip(args_input, args):
+            if isinstance(before, list):
+                assert_bv_list_same_size(before, after)
+            else:
+                assert_bv_same_size(before, after)
+
+        # Set output fields.  The json representation of a program doesn't
+        # record whether a parameter is in/out, so set all params whose args
+        # have changed.  "is" pointer comparison detects changes.
+        for i, param in enumerate(params):
+            if isinstance(param, TypeValueField):
+                if args[i] is args_input[i]:
+                    continue
+                context.set_field_value(param.header_name, param.header_field,
+                                        args[i])
+            else:
+                field_var_names = self.get_header_field_vars(param.header_name)
+                context.set_valid_field(param.header_name)
+                for j, var_name in enumerate(field_var_names):
+                    if args[i][j] is args_input[i][j]:
+                        continue
+                    context.set_field_value(var_name[0], var_name[1],
+                                            args[i][j])
+
 
     @staticmethod
     def parser_transition_key_constraint(sym_transition_keys, value,

--- a/src/p4pktgen/hlir/externs.py
+++ b/src/p4pktgen/hlir/externs.py
@@ -1,0 +1,57 @@
+import os
+import imp
+import inspect
+
+from p4pktgen.config import Config
+
+
+class Externs(object):
+    def __init__(self):
+        self.extern_backends = {}
+
+    @staticmethod
+    def load_external_module(src_path):
+        module_name = os.path.basename(src_path)
+        return imp.load_source(module_name, src_path)
+
+    def load_external_class(self, src_path):
+        external_module = self.load_external_module(src_path)
+        class_list = inspect.getmembers(external_module, inspect.isclass)
+        assert len(class_list) == 1, "Expected exactly one class in {}, got {}".format(
+            external_module.__name__, class_list
+        )
+        return class_list[0][1]
+
+    def load_extern_instance(self, src_path, args):
+        """
+        Loads extern backend from python source file outside of p4pktgen.
+        Source file must contain exactly one class.  The class should have
+        constructor and methods that accept arguments in the z3 equivalents to the
+        p4 arguments.  Typically this will mean BitVecs of the correct size.
+        """
+        extern_class = self.load_external_class(src_path)
+        return extern_class(*args)
+
+    def parse_instance_attribute_values(self, extern_instance):
+        args = []
+        for attr_val in extern_instance.attribute_values:
+            # TODO: Support str and expr arguments as necessary
+            assert attr_val.type == 'hexstr'
+            args.append(int(attr_val.value, 16))
+        return args
+
+    def load_instances(self, extern_instances):
+        extern_definitions = Config().get_extern_definitions()
+        for name, instance in extern_instances.iteritems():
+            assert name in extern_definitions, \
+                "Extern definition not provided for '{}'".format(name)
+            src_file = extern_definitions[name]
+            args = self.parse_instance_attribute_values(instance)
+            self.extern_backends[name] = self.load_extern_instance(src_file, args)
+
+    def get_func(self, instance, function_name):
+        backend = self.extern_backends[instance.name]
+        assert hasattr(backend, function_name),\
+            'Extern definition provided for {} does not implement {}'.format(
+                instance.name, function_name)
+        return getattr(backend, function_name)

--- a/src/p4pktgen/hlir/type_value.py
+++ b/src/p4pktgen/hlir/type_value.py
@@ -136,6 +136,11 @@ class TypeValueLookahead(TypeValue):
         self.size = json_obj[1]
 
 
+class TypeValueExtern(TypeValue):
+    def __init__(self, json_obj):
+        self.extern_instance_name = json_obj
+
+
 def parse_type_value(json_obj):
     p4_type_str = json_obj['type']
     value = json_obj['value']
@@ -180,5 +185,7 @@ def parse_type_value(json_obj):
         return TypeValueRegular(value)
     elif p4_type_str == 'lookahead':
         return TypeValueLookahead(value)
+    elif p4_type_str == 'extern':
+        return TypeValueExtern(value)
     else:
         raise Exception('{} not supported'.format(p4_type_str))

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -212,6 +212,14 @@ def main():
         """With this option given, randomize the generated test-case data where possible."""
     )
     parser.add_argument(
+        '-ed', '--extern-definition',
+        dest='extern_definitions',
+        type=str,
+        action='append',
+        help=
+        """Assign backend implementation source files for externs.  Must be in the form: '<extern-instance-name>:<backend-definition-source>'"""
+    )
+    parser.add_argument(
         dest='input_file', type=str, help='Provide the path to the input file')
 
     # Parse the input arguments
@@ -299,11 +307,12 @@ def generate_test_cases(input_file):
     top.load_json_file(input_file)
 
     top.build_graph()
+    top.load_extern_backends()
     Statistics().init()
 
     # XXX: move
     labels = defaultdict(lambda: EdgeLabels.UNVISITED)
-    path_solver = PathSolver(input_file, top.hlir, top.in_pipeline)
+    path_solver = PathSolver(input_file, top, top.in_pipeline)
     results = OrderedDict()
 
     # TBD: Make this filename specifiable via command line option

--- a/src/p4pktgen/p4_hlir.py
+++ b/src/p4pktgen/p4_hlir.py
@@ -496,6 +496,12 @@ class P4_HLIR(object):
             pipeline = Pipeline(self, pipeline_json)
             self.pipelines[pipeline.name] = pipeline
 
+        # Get any extern instances
+        self.extern_instances = {}
+        for extern_instance_json in json_obj['extern_instances']:
+            extern = ExternInstance(extern_instance_json)
+            self.extern_instances[extern.name] = extern
+
         self.hdr_stacks = None
         self.hdr_union_types = None
         self.hdr_unions = None
@@ -532,6 +538,9 @@ class P4_HLIR(object):
 
     def get_header_type(self, type_name):
         return self.header_types[type_name]
+
+    def get_extern_instance(self, extern_instance_name):
+        return self.extern_instances[extern_instance_name]
 
 
 class PrimitiveCall:
@@ -1039,6 +1048,22 @@ class Pipeline:
                     visited.add(next_table)
 
         return graph, source_info_to_node_name
+
+
+class ExternAttributeValue:
+    def __init__(self, json_obj):
+        self.name = json_obj['name']
+        self.type = json_obj['type']
+        self.value = json_obj['value']
+
+
+class ExternInstance:
+    def __init__(self, json_obj):
+        self.name = json_obj['name']
+        self.id = int(json_obj['id'])
+        self.type = json_obj['type']
+        self.attribute_values = [ExternAttributeValue(v)
+                                 for v in json_obj['attribute_values']]
 
 
 class Calculation:

--- a/src/p4pktgen/p4_top.py
+++ b/src/p4pktgen/p4_top.py
@@ -5,6 +5,7 @@ import json
 from collections import OrderedDict
 
 from p4_hlir import P4_HLIR
+from hlir.externs import Externs
 
 
 def log_graph(name, graph):
@@ -24,6 +25,8 @@ class P4_Top():
         self.json_obj = None
 
         self.hlir = None
+        self.externs = None
+
         self.parser_graph = None
 
         # Ingress graph, required for generating test cases
@@ -56,3 +59,7 @@ class P4_Top():
             self.eg_pipeline = self.hlir.pipelines['egress']
             self.eg_graph, self.eg_source_info_to_node_name = self.eg_pipeline.generate_CFG()
             log_graph('egress', self.eg_graph)
+
+    def load_extern_backends(self):
+        self.externs = Externs()
+        self.externs.load_instances(self.hlir.extern_instances)

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -67,6 +67,7 @@ def load_test_config(no_packet_length_errs=True,
     config.extract_vl_variation = None
     config.consolidate_tables = None
     config.randomize = randomize
+    config.extern_definitions = None
 
 
 def run_test(json_filename):

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -716,6 +716,55 @@ class CheckSystem:
         assert len(table_configs) == 2
         assert len(table_configs[0][0]) > 0, "Config has no commands"
 
+    def check_custom_extern_fields(self, config):
+        # This test checks that when the extern program operating on fields is
+        # provided with a model of an rshift function it is recognised and
+        # implemented correctly.
+        load_test_config(run_simple_switch=False, **config)
+        extern_name = 'ingress.anexterninstance'
+        extern_file = 'examples/externs/rshift_extern.py'
+        Config().extern_definitions = ['{}:{}'.format(extern_name, extern_file)]
+        results = run_test('examples/extern_custom_fields.json')
+        expected_results = {
+            ('start', 'sink', (u'tbl_extern_custom_fields48', u'extern_custom_fields48'), (u'node_3', (True, (u'extern_custom_fields.p4', 49, u'tmp == 0'))), (u'tbl_extern_custom_fields50', u'extern_custom_fields50')):
+                TestPathResult.SUCCESS,
+            ('start', 'sink', (u'tbl_extern_custom_fields48', u'extern_custom_fields48'), (u'node_3', (False, (u'extern_custom_fields.p4', 49, u'tmp == 0')))):
+                TestPathResult.SUCCESS
+        }
+        assert results == expected_results
+
+        # Payloads are 1-byte.  Program rshifts the byte by 5 bits using the
+        # extern, then switches on whether result == 0 or not.
+        payloads = get_packet_payloads(read_test_cases())
+        vals = sorted([int(p, 16) for p in payloads])
+        assert vals[0] < 0x20
+        assert vals[1] >= 0x20
+
+    def check_custom_extern_headers(self, config):
+        # This test checks that when the extern program operating on headers is
+        # provided with a model of an rshift function it is recognised and
+        # implemented correctly.
+        load_test_config(run_simple_switch=False, **config)
+        extern_name = 'ingress.anexterninstance'
+        extern_file = 'examples/externs/rshift_extern.py'
+        Config().extern_definitions = ['{}:{}'.format(extern_name, extern_file)]
+        results = run_test('examples/extern_custom_headers.json')
+        expected_results = {
+            ('start', 'sink', (u'tbl_extern_custom_headers48', u'extern_custom_headers48'), (u'node_3', (True, (u'extern_custom_headers.p4', 49, u'tmp.data == 0'))), (u'tbl_extern_custom_headers50', u'extern_custom_headers50')):
+                TestPathResult.SUCCESS,
+            ('start', 'sink', (u'tbl_extern_custom_headers48', u'extern_custom_headers48'), (u'node_3', (False, (u'extern_custom_headers.p4', 49, u'tmp.data == 0')))):
+                TestPathResult.SUCCESS
+        }
+
+        assert results == expected_results
+
+        # Payloads are 1-byte.  Program rshifts the byte by 5 bits using the
+        # extern, then switches on whether result == 0 or not.
+        payloads = get_packet_payloads(read_test_cases())
+        vals = sorted([int(p, 16) for p in payloads])
+        assert vals[0] < 0x20
+        assert vals[1] >= 0x20
+
 
     def check_parser_error(self, config):
         # This test case checks that the parser_error standard metadata field


### PR DESCRIPTION
Adds support for programs with externs.

The implementation of the extern must be written separately and linked with the program via a command line option.