### PR TITLE
for-upstream/visit-loop-refactor

### DIFF
--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -400,16 +400,18 @@ class TableConsolidatedSolver(ConsolidatedSolver):
         return super(TableConsolidatedSolver, self)._try_add_path(
             path_id, new_constraints, path_data)
 
-    def add_path(self, path, constraints, context, sym_packet):
+    def add_path(self, path_solution):
+        path = path_solution.path
         prefix = 'path{}/'.format(path.id)
         var_mapping = {}  # {old_param: new_param, ... }
 
-        new_constraints = \
-            path_specific_constraints(prefix, constraints, var_mapping)
+        new_constraints = path_specific_constraints(
+            prefix, path_solution.constraints, var_mapping)
 
-        new_sym_packet = \
-            path_specific_packet(prefix, sym_packet, var_mapping)
+        new_sym_packet = path_specific_packet(
+            prefix, path_solution.sym_packet, var_mapping)
 
+        context = path_solution.context
         table_names = context.table_key_values.keys()
         assert set(table_names) == set(context.table_runtime_data.keys())
         table_data = {}
@@ -428,6 +430,7 @@ class TableConsolidatedSolver(ConsolidatedSolver):
             var_name: path_specific_expr(prefix, var, var_mapping)
             for var_name, var in context.input_metadata.iteritems()
         }
+
         path_data = (
             new_sym_packet, path, input_metadata,
             context.uninitialized_reads, context.invalid_header_writes,

--- a/src/p4pktgen/core/context.py
+++ b/src/p4pktgen/core/context.py
@@ -2,10 +2,8 @@
 # - Print out which values were used for constraints.
 
 from collections import defaultdict
-import logging
 from contextlib import contextmanager
 import random
-import time
 
 from z3 import *
 

--- a/src/p4pktgen/core/generator.py
+++ b/src/p4pktgen/core/generator.py
@@ -1,0 +1,122 @@
+import logging
+
+from collections import defaultdict, OrderedDict
+
+from p4pktgen.config import Config
+from p4pktgen.core.strategy import PathCoverageGraphVisitor, EdgeCoverageGraphVisitor
+from p4pktgen.core.solver import PathSolver
+from p4pktgen.core.consolidator import TableConsolidatedSolver
+from p4pktgen.hlir.transition import NoopTransition
+from p4pktgen.util.graph import Graph
+from p4pktgen.util.test_case_writer import TestCaseWriter
+from p4pktgen.util.statistics import Statistics
+
+
+def create_noop_control_graph():
+    graph = Graph()
+    v_start = 'fake_init_table'
+    edge = NoopTransition(v_start, None)
+    graph.add_edge(edge.src, edge.dst, edge)
+    return v_start, graph
+
+
+def path_tuple(parser_path, control_path):
+    """Returns a tuple structure of strings and Transition objects representing
+    the vertices traversed by a path.  Note that the mapping is not injective,
+    because a pair of vertices may be joined by multiple edges."""
+    return tuple(
+        [n.src for n in parser_path] +
+        ['sink'] +
+        [(n.src, n) for n in control_path]
+    )
+
+
+class TestCaseGenerator(object):
+    def __init__(self, input_file, top):
+        self.input_file = input_file
+        self.top = top
+
+    def get_control_graph(self):
+        if self.top.in_pipeline.init_table_name is None:
+            return create_noop_control_graph()
+        start_node = self.top.in_pipeline.init_table_name
+        control_graph = self.top.in_graph
+        return start_node, control_graph
+
+
+    def generate_test_cases_for_parser_paths(self, parser_paths):
+        Statistics().init()
+
+        # XXX: move
+        path_solver = PathSolver(self.input_file, self.top, self.top.in_pipeline)
+        results = OrderedDict()
+
+        # TBD: Make this filename specifiable via command line option
+        test_case_writer = TestCaseWriter(
+            Config().get_output_json_path(),
+            Config().get_output_pcap_path()
+        )
+
+        table_solver = None
+        if Config().get_do_consolidate_tables():
+            table_solver = \
+                TableConsolidatedSolver(self.input_file, self.top.in_pipeline,
+                                        test_case_writer)
+
+        start_node, control_graph = self.get_control_graph()
+
+        # XXX: move
+        path_count = defaultdict(int)
+
+        for i_path, parser_path in enumerate(parser_paths):
+            for e in parser_path:
+                if path_count[e] == 0:
+                    Statistics().num_covered_edges += 1
+                path_count[e] += 1
+            logging.info("Analyzing parser_path %d of %d: %s"
+                         "" % (i_path, len(parser_paths), parser_path))
+            if not path_solver.generate_parser_constraints(parser_path):
+                logging.info("Could not find any packet to satisfy parser path: %s"
+                             "" % (parser_path))
+                # Skip unsatisfiable parser paths
+                continue
+
+            if Config().get_edge_coverage():
+                graph_visitor = EdgeCoverageGraphVisitor(path_solver, table_solver, parser_path,
+                                                         self.top.in_source_info_to_node_name,
+                                                         results, test_case_writer, control_graph)
+            else:
+                graph_visitor = PathCoverageGraphVisitor(path_solver, table_solver, parser_path,
+                                                         self.top.in_source_info_to_node_name,
+                                                         results, test_case_writer)
+
+            control_graph.visit_all_paths(start_node, None, graph_visitor)
+
+            # Check if we generated enough test cases
+            if Statistics().num_test_cases == Config().get_num_test_cases():
+                break
+
+        if Config().get_do_consolidate_tables():
+            table_solver.flush()
+
+        logging.info("Final statistics on use of control path edges:")
+        Statistics().log_control_path_stats(
+            Statistics().stats_per_control_path_edge, Statistics().num_control_path_edges)
+        test_case_writer.cleanup()
+        path_solver.cleanup()
+
+        Statistics().dump()
+        Statistics().cleanup()
+
+        for result, count in Statistics().stats.items():
+            print('{}: {}'.format(result, count))
+
+        if Config().get_dump_test_case():
+            str_items = []
+            for (parser_path, control_path), v in results.items():
+                str_items.append('{}: {}'.format(path_tuple(parser_path,
+                                                            control_path), v))
+            print('{{ {} }}'.format(', '.join(str_items)))
+
+        return results
+

--- a/src/p4pktgen/core/generator.py
+++ b/src/p4pktgen/core/generator.py
@@ -66,13 +66,12 @@ class TestCaseGenerator(object):
         start_node, control_graph = self.get_control_graph()
 
         # XXX: move
-        path_count = defaultdict(int)
-
+        parser_path_edge_count = defaultdict(int)
         for i_path, parser_path in enumerate(parser_paths):
             for e in parser_path:
-                if path_count[e] == 0:
+                if parser_path_edge_count[e] == 0:
                     Statistics().num_covered_edges += 1
-                path_count[e] += 1
+                parser_path_edge_count[e] += 1
             logging.info("Analyzing parser_path %d of %d: %s"
                          "" % (i_path, len(parser_paths), parser_path))
             if not path_solver.generate_parser_constraints(parser_path):
@@ -119,4 +118,3 @@ class TestCaseGenerator(object):
             print('{{ {} }}'.format(', '.join(str_items)))
 
         return results
-

--- a/src/p4pktgen/core/packet.py
+++ b/src/p4pktgen/core/packet.py
@@ -1,10 +1,9 @@
 from z3 import *
 
-import logging
-
 from p4pktgen.config import Config
 from p4pktgen.core.context import Variables
 from p4pktgen.util.bitvec import equalize_bv_size, LShREq
+
 
 class Packet(object):
     """The symbolic representation of a packet."""

--- a/src/p4pktgen/core/path.py
+++ b/src/p4pktgen/core/path.py
@@ -1,0 +1,14 @@
+class Path(object):
+    def __init__(self, id, expected_path, parser_path, control_path, is_complete):
+        self.id = id
+        self.expected_path = expected_path
+        self.parser_path = parser_path
+        self.control_path = control_path
+        self.is_complete = is_complete
+
+    def __str__(self):
+        return "%d Exp path (len %d+%d=%d) complete_path %s: %s" % (
+            self.id, len(self.parser_path), len(self.control_path),
+            len(self.parser_path) + len(self.control_path),
+            self.is_complete, self.expected_path
+        )

--- a/src/p4pktgen/core/path.py
+++ b/src/p4pktgen/core/path.py
@@ -21,24 +21,31 @@ class Path(object):
 
 
 class PathSolution(object):
-    def __init__(self, path, result, constraints, context, sym_packet, model):
+    def __init__(self, path, result, constraints, context, sym_packet, model,
+                 time_sec_solve=None):
         self.path = path
         self.result = result
         self.constraints = constraints
         self.context = context
         self.sym_packet = sym_packet
         self.model = model
+        self.time_sec_solve=time_sec_solve
 
 
 class PathModel(object):
-    def __init__(self, path, result, path_solver):
+    def __init__(self, path, result, path_solver,
+                 time_sec_generate_ingress_constraints=None,
+                 time_sec_initial_solve=None):
         self.path = path
         self.result = result
         self.path_solver = path_solver
+        self.time_sec_generate_ingress_constraints = time_sec_generate_ingress_constraints
+        self.time_sec_initial_solve = time_sec_initial_solve
 
     def solutions(self):
         extract_vl_variation = Config().get_extract_vl_variation()
         current_result = self.result
+        solve_time = self.time_sec_initial_solve
         while current_result != TestPathResult.NO_PACKET_FOUND:
             assert current_result == self.result
 
@@ -56,6 +63,7 @@ class PathModel(object):
                     self.path_solver.current_context(),
                     self.path_solver.sym_packet,
                     self.path_solver.solver.model(),
+                    time_sec_solve=solve_time,
                 )
                 yield path_solution
             finally:
@@ -71,4 +79,6 @@ class PathModel(object):
                 if not Config().get_max_test_cases_per_path():
                     break
 
+            time2 = time.time()
             current_result = self.path_solver.solve_path()
+            solve_time = time.time()

--- a/src/p4pktgen/core/path.py
+++ b/src/p4pktgen/core/path.py
@@ -1,3 +1,9 @@
+import time
+
+from p4pktgen.config import Config
+from p4pktgen.core.test_cases import TestPathResult
+
+
 class Path(object):
     def __init__(self, id, expected_path, parser_path, control_path, is_complete):
         self.id = id
@@ -12,3 +18,57 @@ class Path(object):
             len(self.parser_path) + len(self.control_path),
             self.is_complete, self.expected_path
         )
+
+
+class PathSolution(object):
+    def __init__(self, path, result, constraints, context, sym_packet, model):
+        self.path = path
+        self.result = result
+        self.constraints = constraints
+        self.context = context
+        self.sym_packet = sym_packet
+        self.model = model
+
+
+class PathModel(object):
+    def __init__(self, path, result, path_solver):
+        self.path = path
+        self.result = result
+        self.path_solver = path_solver
+
+    def solutions(self):
+        extract_vl_variation = Config().get_extract_vl_variation()
+        current_result = self.result
+        while current_result != TestPathResult.NO_PACKET_FOUND:
+            assert current_result == self.result
+
+            # Choose values for randomization variables.
+            random_constraints = []
+            fix_random = self.path.is_complete
+            if fix_random:
+                self.path_solver.push()
+                random_constraints = self.path_solver.fix_random_constraints()
+
+            try:
+                path_solution = PathSolution(
+                    self.path, self.result,
+                    self.path_solver.constraints + [random_constraints],
+                    self.path_solver.current_context(),
+                    self.path_solver.sym_packet,
+                    self.path_solver.solver.model(),
+                )
+                yield path_solution
+            finally:
+                # Clear the constraints on the values of the randomization
+                # variables.
+                if fix_random:
+                    self.path_solver.pop()
+
+            if not self.path_solver.constrain_last_extract_vl_lengths(extract_vl_variation):
+                # Special case: unbounded numbers of test cases are only
+                # safe when we're building up constraints on VL-extraction
+                # lengths, or else we'll loop forever.
+                if not Config().get_max_test_cases_per_path():
+                    break
+
+            current_result = self.path_solver.solve_path()

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -358,24 +358,20 @@ class PathSolver(object):
             assert self.solver_result == sat
         return constraints
 
-    def generate_test_case(self, expected_path,
-                           parser_path, control_path, is_complete_control_path,
-                           source_info_to_node_name):
+    def generate_test_case(self, path, source_info_to_node_name):
         context = self.current_context()
         model = self.solver.model() if self.solver_result == sat else None
 
         start_time = time.time()
         result, test_case, payloads = \
             self.test_case_builder.build_for_path(
-                context, model, self.sym_packet, expected_path,
-                parser_path, control_path, is_complete_control_path,
-                self.path_id
+                context, model, self.sym_packet, path
             )
 
         if Config().get_run_simple_switch():
             result = self.test_case_builder.run_simple_switch(
-                expected_path, test_case, payloads,
-                is_complete_control_path, source_info_to_node_name)
+                path.expected_path, test_case, payloads,
+                path.is_complete, source_info_to_node_name)
 
         self.total_switch_time += time.time() - start_time
 

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -3,14 +3,10 @@
 # - Position is a 32-bit integer right now. Smaller/larger?
 # - Move to smt-switch
 
-import copy
-import logging
 import time
 
-from enum import Enum
 from z3 import *
 
-from p4pktgen.config import Config
 from p4pktgen.core.context import Context
 from p4pktgen.core.packet import Packet
 from p4pktgen.core.translator import Translator
@@ -19,7 +15,6 @@ from p4pktgen.hlir.transition import *
 from p4pktgen.hlir.type_value import *
 from p4pktgen.p4_hlir import *
 from p4pktgen.util.statistics import Statistics, Timer
-from p4pktgen.util.table import Table
 
 
 class PathSolver(object):

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -370,14 +370,17 @@ class PathSolver(object):
             assert self.solver_result == sat
         return constraints
 
-    def generate_test_case(self, path, result, source_info_to_node_name):
-        context = self.current_context()
-        model = self.solver.model() if self.solver_result == sat else None
+    def generate_test_case(self, path_solution, source_info_to_node_name):
+        path = path_solution.path
+        result = path_solution.result
+        context = path_solution.context
+        sym_packet = path_solution.sym_packet
+        model = path_solution.model
 
         start_time = time.time()
         build_result, test_case, payloads = \
             self.test_case_builder.build_for_path(
-                context, model, self.sym_packet, path
+                context, model, sym_packet, path
             )
         assert build_result == result
 

--- a/src/p4pktgen/core/strategy.py
+++ b/src/p4pktgen/core/strategy.py
@@ -1,11 +1,6 @@
 from collections import defaultdict
 import time
 import logging
-from random import shuffle
-import operator
-import random
-
-from enum import Enum
 
 from p4pktgen.config import Config
 from p4pktgen.core.test_cases import TestPathResult, record_test_case

--- a/src/p4pktgen/core/test_cases.py
+++ b/src/p4pktgen/core/test_cases.py
@@ -1,6 +1,4 @@
-import os
 import logging
-import tempfile
 
 from enum import Enum
 

--- a/src/p4pktgen/core/translator.py
+++ b/src/p4pktgen/core/translator.py
@@ -1,8 +1,5 @@
-import logging
-
 from z3 import *
 
-from p4pktgen.config import Config
 from p4pktgen.hlir.transition import *
 from p4pktgen.hlir.type_value import *
 from p4pktgen.p4_hlir import *

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -278,9 +278,11 @@ def generate_test_cases(input_file):
     Statistics().num_control_path_edges = num_parser_path_edges + num_control_path_edges
 
     graph_visitor = ParserGraphVisitor(top.hlir)
-    top.parser_graph.visit_all_paths(top.hlir.parsers['parser'].init_state, 'sink',
-                                     graph_visitor)
-    parser_paths = graph_visitor.all_paths
+    parser_paths = [
+        path for path in
+        top.parser_graph.visit_all_paths(top.hlir.parsers['parser'].init_state,
+                                         'sink', graph_visitor)
+    ]
 
     max_path_len = max([len(p) for p in parser_paths])
     logging.info("Found %d parser paths, longest with length %d"

--- a/src/p4pktgen/util/graph.py
+++ b/src/p4pktgen/util/graph.py
@@ -408,7 +408,12 @@ class Graph:
                 graph_visitor.backtrack()
             last_len = len(current_path)
 
-            visit_result = graph_visitor.visit(current_path, is_full_path)
+            visit_result, path_data = graph_visitor.visit(current_path, is_full_path)
+            if path_data is not None:
+                # There can be no path to yield if it is unsatisfiable, or no
+                # state has been created to return (e.g. quick_solve).
+                yield path_data
+
             if visit_result == VisitResult.CONTINUE and not is_full_path:
                 for e in graph_visitor.preprocess_edges(current_path,
                         self.get_neighbors(last_node)):

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -195,45 +195,48 @@ class CheckSystem:
         }
         assert results == expected_results
 
+    # This program and results are used by various tests.
+    demo9b_expected_results = {
+        ('start', 'parse_ethernet', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'parse_tcp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'parse_udp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv4', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.UNINITIALIZED_READ,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
+        TestPathResult.SUCCESS,
+        ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
+        TestPathResult.SUCCESS
+    }
+
     def check_demo9b(self, config):
         load_test_config(**config)
         results = run_test('examples/demo9b.json')
-        expected_results = {
-            ('start', 'parse_ethernet', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'parse_tcp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'parse_udp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv4', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.UNINITIALIZED_READ,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (True, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6')))):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_tcp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (False, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act_0', u'act_0')):
-            TestPathResult.SUCCESS,
-            ('start', 'parse_ethernet', 'parse_ipv6', 'parse_udp', 'sink', (u'node_2', (False, (u'demo9b.p4', 157, u'hdr.ipv6.version != 6'))), (u'node_3', (True, (u'demo9b.p4', 160, u'hdr.ethernet.srcAddr == 123456'))), (u'tbl_act', u'act')):
-            TestPathResult.SUCCESS
-        }
+        expected_results = self.demo9b_expected_results
         assert results == expected_results
 
     def check_config_table(self, config):
@@ -890,6 +893,19 @@ class CheckSystem:
             ('start', 'sink', (u'node_2', (False, (u'edge_coverage_unsat.p4', 65, u'h.a.data == 0'))), (u'tbl_edge_coverage_unsat69', u'edge_coverage_unsat69'), (u'node_5', (False, (u'edge_coverage_unsat.p4', 72, u'h.x.data == 5'))), (u'node_7', (False, (u'edge_coverage_unsat.p4', 79, u'h.a.data == 0'))), (u'node_13', (False, (u'edge_coverage_unsat.p4', 89, u'h.b.data == 0'))), (u'node_15', (False, (u'edge_coverage_unsat.p4', 91, u'h.b.data == 1'))), (u'tbl_edge_coverage_unsat94', u'edge_coverage_unsat94')): TestPathResult.SUCCESS,
             ('start', 'sink', (u'node_2', (False, (u'edge_coverage_unsat.p4', 65, u'h.a.data == 0'))), (u'tbl_edge_coverage_unsat69', u'edge_coverage_unsat69'), (u'node_5', (False, (u'edge_coverage_unsat.p4', 72, u'h.x.data == 5'))), (u'node_7', (False, (u'edge_coverage_unsat.p4', 79, u'h.a.data == 0'))), (u'node_13', (False, (u'edge_coverage_unsat.p4', 89, u'h.b.data == 0'))), (u'node_15', (True, (u'edge_coverage_unsat.p4', 91, u'h.b.data == 1'))), (u'tbl_edge_coverage_unsat92', u'edge_coverage_unsat92')): TestPathResult.SUCCESS,
         }
+        assert results == expected_results
+
+    def check_demo9b_limit_num_test_cases(self, config):
+        load_test_config(**config)
+        Config().num_test_cases = 7
+        results = run_test('examples/demo9b.json')
+        expected_results_items = sorted(self.demo9b_expected_results.items())
+        # Through experimentation we happen to know that these are the first 7
+        # test cases to be generated with the default config.
+        expected_items_indexes = [9, 10, 12, 13, 14, 15, 16]
+        expected_results_items = [expected_results_items[i]
+                                  for i in expected_items_indexes]
+        expected_results = {k: v for k, v in expected_results_items}
         assert results == expected_results
 
 


### PR DESCRIPTION
Refactor the loop that visits different paths in the control graph into a new class.
Moving this from a module function in main lets us chop up the logic more easily, which we need to do to implement a round-robin visit strategy in the next PR.