### PR TITLE
for-upstream/round-robin-parser-paths

### DIFF
--- a/src/p4pktgen/config.py
+++ b/src/p4pktgen/config.py
@@ -28,6 +28,7 @@ class Config:
         self.table_opt = args.table_opt
         self.incremental = args.incremental
         self.output_path = './test-case'
+        self.round_robin_parser_paths = args.round_robin_parser_paths
         self.extract_vl_variation = args.extract_vl_variation
         self.consolidate_tables = args.consolidate_tables
         self.randomize = args.randomize
@@ -98,6 +99,9 @@ class Config:
 
     def get_output_pcap_path(self):
         return self.output_path + '.pcap'
+
+    def get_round_robin_parser_paths(self):
+        return self.round_robin_parser_paths
 
     def get_extract_vl_variation(self):
         if self.extract_vl_variation is None or \

--- a/src/p4pktgen/core/path.py
+++ b/src/p4pktgen/core/path.py
@@ -22,6 +22,7 @@ class Path(object):
 
 class PathSolution(object):
     def __init__(self, path, result, constraints, context, sym_packet, model,
+                 time_sec_generate_ingress_constraints=None,
                  time_sec_solve=None):
         self.path = path
         self.result = result
@@ -29,6 +30,7 @@ class PathSolution(object):
         self.context = context
         self.sym_packet = sym_packet
         self.model = model
+        self.time_sec_generate_ingress_constraints = time_sec_generate_ingress_constraints
         self.time_sec_solve=time_sec_solve
 
 
@@ -63,6 +65,7 @@ class PathModel(object):
                     self.path_solver.current_context(),
                     self.path_solver.sym_packet,
                     self.path_solver.solver.model(),
+                    time_sec_generate_ingress_constraints=self.time_sec_generate_ingress_constraints,
                     time_sec_solve=solve_time,
                 )
                 yield path_solution

--- a/src/p4pktgen/main.py
+++ b/src/p4pktgen/main.py
@@ -194,6 +194,14 @@ def main():
         """With this option given, consolidate test-cases around common tables up to the maximum value given (omit value for unlimited).  Currently incompatible with max_test_cases_per_path != 1."""
     )
     parser.add_argument(
+        '-rr', '--round-robin-parser-paths',
+        dest='round_robin_parser_paths',
+        action='store_true',
+        default=False,
+        help=
+        """With this option given, round robin over parser paths when generating test cases.  Note that this may use large amounts of memory on jobs with many parser paths."""
+    )
+    parser.add_argument(
         '-rnd', '--randomize',
         dest='randomize',
         action='store_true',

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -63,6 +63,7 @@ def load_test_config(no_packet_length_errs=True,
     config.table_opt = True
     config.incremental = True
     config.output_path = './test-case'
+    config.round_robin_parser_paths = False
     config.extract_vl_variation = None
     config.consolidate_tables = None
     config.randomize = randomize

--- a/tests/check_system.py
+++ b/tests/check_system.py
@@ -909,6 +909,27 @@ class CheckSystem:
         expected_results = {k: v for k, v in expected_results_items}
         assert results == expected_results
 
+    def check_demo9b_round_robin(self, config):
+        load_test_config(**config)
+        Config().round_robin_parser_paths = True
+        results = run_test('examples/demo9b.json')
+        expected_results = self.demo9b_expected_results
+        assert results == expected_results
+
+    def check_demo9b_round_robin_limited(self, config):
+        load_test_config(**config)
+        Config().round_robin_parser_paths = True
+        Config().num_test_cases = 7  # There are 7 parser paths in demo9b
+        results = run_test('examples/demo9b.json')
+        expected_results_items = sorted(self.demo9b_expected_results.items())
+        # Through experimentation we happen to know that these are the first
+        # test cases on each of the 7 parser paths.
+        expected_items_indexes = [0, 2, 4, 6, 9, 12, 15]
+        expected_results_items = [expected_results_items[i]
+                                  for i in expected_items_indexes]
+        expected_results = {k: v for k, v in expected_results_items}
+        assert results == expected_results
+
 
 class CheckRandomization(object):
     @pytest.mark.parametrize('consolidate', [False, True],


### PR DESCRIPTION
Factors out the linear nature of parser path visitation from the main visit loop.
Adds an option to round-robin over parser paths instead.
This is aimed at getting better coverage of parser paths when p4pktgen is stopped before it generates all paths, either because the user cancels it, or because there is a limit set on the number of test cases.