### PR TITLE
for-upstream/solve-again

### DIFF
--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -393,7 +393,7 @@ class TableConsolidatedSolver(ConsolidatedSolver):
         new_constraints = list(constraints)
         for table_name, (action_name, path_sym_key, path_sym_params) \
                 in table_data.iteritems():
-            new_constraints.extend(self.consolidated_constraints(
+            new_constraints.append(self.consolidated_constraints(
                 table_name, action_name,
                 path_sym_key, path_sym_params))
 

--- a/src/p4pktgen/core/consolidator.py
+++ b/src/p4pktgen/core/consolidator.py
@@ -164,7 +164,8 @@ class ConsolidatedSolver(object):
         self.paths_data.append((path_id, path_data))
         self.solver.push()
         for cs in constraints:
-            self.solver.add(z3.And(cs))
+            if len(cs) > 0:
+                self.solver.add(z3.And(cs))
 
         result = self.solve()
         if result != z3.sat:

--- a/src/p4pktgen/core/solver.py
+++ b/src/p4pktgen/core/solver.py
@@ -337,11 +337,13 @@ class PathSolver(object):
         if not Config().get_incremental():
             # Add constraints from each previous path node
             for cs in self.constraints:
-                self.solver.add(And(cs))
+                if len(cs) > 0:
+                    self.solver.add(And(cs))
         self.constraints[-1].extend(constraints)
 
         # logging.debug(And(constraints))
-        self.solver.add(And(constraints))
+        if len(constraints) > 0:
+            self.solver.add(And(constraints))
         self.solver_result = None
 
     def try_quick_solve(self, control_path, is_complete_control_path):


### PR DESCRIPTION
The z3 solver that we use has some optimisations that kick in if solves are done incrementally.
This is a problem for randomization as it can lead to fields that would be randomized favouring particular values over others.
Deal with the issue by resetting the solver and solving again from scratch when generating test cases.

In practical terms this means that the consolidated version of our directed randomization test fails after this commit to z3:
https://github.com/Z3Prover/z3/commit/e22f713b19a73c6e2efd8dd3fe4917c4f8c2ce62
Whatever optimization causes this issue is not added by the commit, it's just that the tuning that it does causes the test to hit it.

The problem can be observed directly through the following program (pseudocode):
```
x = new_var('x', 8)  # Creates a bitvec using our random displacement code (see Variables class)
solver.add(x & 0xbb == 0xbb)  # 2 free bits, 4 possible values for x
solve()

y =new_var('y', 8)
solver.add(y & 0xbb == 0xbb)  # same restrictions as x
solver.add(x != y)  # each still free to pick any of the other 3 values
solve()

fix_random_vars()  # (see Variables class)
solve()  # Final solve
eval(x)  # Both x and y will favour some values over others
```
If any of the incremental solves are removed then the issue will not occur.
While possible, this series of constraints is unlikely to occur in a single path through a program, so shouldn't affect non-consolidated test-cases.  However, it is extremely likely to occur when consolidating.