### PR TITLE
Use standard install script to setup Travis environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,7 @@ script:
   - cd ..
   - sudo ldconfig
   - simple_switch --version
-  - pip install --upgrade pip
-  - pip install virtualenv
-  - virtualenv test-env --python=python3 --system-site-packages
-  - source test-env/bin/activate
-  - pip install -r requirements.txt
-  - python setup.py develop
+  - ./tools/install.sh
+  - source my-venv/bin/activate
   - pytest
   - ccache -s


### PR DESCRIPTION
Avoids having to duplicate changes to the install process in the Travis
file.